### PR TITLE
Fixed a couple of warnings present in Xcode 4.2

### DIFF
--- a/Kiwi/KWExampleGroupBuilder.m
+++ b/Kiwi/KWExampleGroupBuilder.m
@@ -69,7 +69,7 @@ static KWExampleGroupBuilder *sharedExampleGroupBuilder = nil;
     return NSUIntegerMax;
 }
 
-- (void)release {
+- (oneway void)release {
 }
 
 - (id)autorelease {

--- a/Kiwi/KWMock.m
+++ b/Kiwi/KWMock.m
@@ -179,7 +179,7 @@ static NSString * const StubValueKey = @"StubValueKey";
         [protocolQueue removeLastObject];
         
         unsigned int count = 0;
-        Protocol **protocols = protocol_copyProtocolList(protocol, &count);
+        Protocol **protocols = (Protocol **)protocol_copyProtocolList(protocol, &count);
         
         if (count == 0)
             continue;

--- a/Kiwi/KWNull.m
+++ b/Kiwi/KWNull.m
@@ -37,7 +37,7 @@ static KWNull *sharedNull = nil;
     return NSUIntegerMax;
 }
 
-- (void)release {
+- (oneway void)release {
 }
 
 - (id)autorelease {


### PR DESCRIPTION
Fixed warnings related to oneway void definition of release and added a cast to suppress warning on invocation of protocol_copyProtocolList.
