### PR TITLE
Detect blocks as an object as apposed to a 'value type'

### DIFF
--- a/Kiwi/KWObjCUtilities.m
+++ b/Kiwi/KWObjCUtilities.m
@@ -43,7 +43,7 @@ BOOL KWObjCTypeIsUnsignedIntegral(const char *objCType) {
 }
 
 BOOL KWObjCTypeIsObject(const char *objCType) {
-    return strcmp(objCType, @encode(id)) == 0;
+    return strcmp(objCType, @encode(id)) == 0 || strcmp(objCType, "@?") == 0;
 }
 
 BOOL KWObjCTypeIsCharString(const char *objCType) {


### PR DESCRIPTION
This patch will properly detect a block as an object. This should fix mocking issues related to 'fuzzy' matchers using hamcrest.
