### PR TITLE
Add C++ guards

### DIFF
--- a/Kiwi/Kiwi.h
+++ b/Kiwi/Kiwi.h
@@ -8,6 +8,10 @@
 #import "KiwiConfiguration.h"
 #import <SenTestingKit/SenTestingKit.h>
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+    
 #import "KWAfterAllNode.h"
 #import "KWAfterEachNode.h"
 #import "KWAsyncVerifier.h"
@@ -83,3 +87,8 @@
 #ifndef KIWI_DISABLE_MACRO_API
   #import "KiwiBlockMacros.h"
 #endif
+    
+#if defined(__cplusplus)
+}
+#endif
+


### PR DESCRIPTION
This allows for using Kiwi to test Objective-C++.
