### PR TITLE
ARC Compatibility

### DIFF
--- a/Kiwi/KWFutureObject.h
+++ b/Kiwi/KWFutureObject.h
@@ -11,7 +11,7 @@
 typedef id (^KWFutureObjectBlock)(void);
 
 @interface KWFutureObject : NSObject {
-  id *objectPointer;
+  __weak id *objectPointer;
   KWFutureObjectBlock block;
 }
 + (id)objectWithObjectPointer:(id *)pointer;


### PR DESCRIPTION
I've successfully got Kiwi working in an ARC using iOS project. I had to make this one small code change to get the code building. Instead of adding the non-ARC compatible files to my project I set up my test target to link against the the Kiwi static library. This involved:
1. Add libKiwi.a as a dependency of my test target
2. Add libKiwi.a to the linked frameworks of the test target
3. Add `-ObjC -force_load ${BUILT_PRODUCTS_DIR}/libKiwi.a` to the Other Linker Flags project setting of the test target

After this the specs run.
