### PR TITLE
Update podspec to use the updated accessor style and bump to a future version.

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -1,11 +1,11 @@
-Pod::Spec.new do
-  name         'Kiwi'
-  version      '1.0.0'
-  summary      'A Behavior Driven Development library for iPhone and iPad development.'
-  homepage     'http://kiwi-lib.info'
-  authors      'Allen Ding' => 'allen@allending.com', 'Luke Redpath' => 'luke@lukeredpath.co.uk'
-  source       :git => 'https://github.com/allending/Kiwi.git', :tag => 'v1.0.0'
-  source_files 'Kiwi'
-  xcconfig     'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks"',
-               'OTHER_LDFLAGS' => '-ObjC -all_load -framework SenTestingKit'
+Pod::Spec.new do |s|
+  s.name         = 'Kiwi'
+  s.version      = '1.0.1'
+  s.summary      = 'A Behavior Driven Development library for iPhone and iPad development.'
+  s.homepage     = 'http://kiwi-lib.info'
+  s.authors      = { 'Allen Ding' => 'allen@allending.com', 'Luke Redpath' => 'luke@lukeredpath.co.uk' }
+  s.source       = { :git => 'https://github.com/allending/Kiwi.git', :tag => 'v1.0.1' }
+  s.source_files = 'Kiwi'
+  s.framework    = 'SenTestingKit'
+  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks"' }
 end


### PR DESCRIPTION
Adding this allows users to install the HEAD version directly from your repo, instead of a released version.

The next version does not neccesarilly have to be 1.0.1, but it's the
smallest increment, so it will always be a sane version number.
