### PR TITLE
Warnings with AsyncVerifier macros.

### DIFF
--- a/Kiwi/KWAsyncVerifier.h
+++ b/Kiwi/KWAsyncVerifier.h
@@ -16,11 +16,11 @@
 
 @interface KWAsyncVerifier : KWMatchVerifier
 {
-  NSInteger timeout;
+  NSTimeInterval timeout;
 }
-@property (nonatomic, assign) NSInteger timeout;
+@property (nonatomic, assign) NSTimeInterval timeout;
 
-+ (id)asyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite matcherFactory:(KWMatcherFactory *)aMatcherFactory reporter:(id<KWReporting>)aReporter probeTimeout:(NSInteger)probeTimeout;
++ (id)asyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite matcherFactory:(KWMatcherFactory *)aMatcherFactory reporter:(id<KWReporting>)aReporter probeTimeout:(NSTimeInterval)probeTimeout;
 - (void)verifyWithProbe:(KWAsyncMatcherProbe *)aProbe;
 @end
 

--- a/Kiwi/KWAsyncVerifier.m
+++ b/Kiwi/KWAsyncVerifier.m
@@ -16,7 +16,7 @@
 
 @synthesize timeout;
 
-+ (id)asyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite matcherFactory:(KWMatcherFactory *)aMatcherFactory reporter:(id<KWReporting>)aReporter probeTimeout:(NSInteger)probeTimeout;
++ (id)asyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite matcherFactory:(KWMatcherFactory *)aMatcherFactory reporter:(id<KWReporting>)aReporter probeTimeout:(NSTimeInterval)probeTimeout;
 {
   KWAsyncVerifier *verifier = [[self alloc] initWithExpectationType:anExpectationType callSite:aCallSite matcherFactory:aMatcherFactory reporter:aReporter];
   verifier.timeout = probeTimeout;


### PR DESCRIPTION
...r to avoid compiler warning for clients using warnings on implicit conversions (the default timeout is defined as 1.0 and converted to NSUInteger in a few cases). If you pass in a negative timeinterval, you deserve unexpected behavior.
