### PR TITLE
fixed KWExampleGroupBuilderTests

### DIFF
--- a/Kiwi/KWDeviceInfo.m
+++ b/Kiwi/KWDeviceInfo.m
@@ -19,8 +19,7 @@
 
 + (BOOL)isSimulator {
 #if TARGET_IPHONE_SIMULATOR
-    NSString *model = [[UIDevice currentDevice] model];
-    return [model hasSuffix:@" Simulator"];
+    return YES;
 #else
     return NO;
 #endif // #if TARGET_IPHONE_SIMULATOR

--- a/Tests/KWExampleGroupBuilderTest.m
+++ b/Tests/KWExampleGroupBuilderTest.m
@@ -16,44 +16,30 @@
 
 @implementation KWExampleGroupBuilderTest
 
-- (void)testItShouldStartExampleGroups {
-    STAssertNoThrow([[KWExampleGroupBuilder sharedExampleGroupBuilder] startExampleGroups], @"expected example group to be started");
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups];
-    STAssertFalse([[KWExampleGroupBuilder sharedExampleGroupBuilder] isBuildingExampleGroup], @"example group builder must be clean for other tests to run cleanly");
-}
-
-- (void)testItShouldEndAndCreateExampleGroups {
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] startExampleGroups];
-    id exampleGroup = [[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups];
+- (void)testItShouldBuildExampleGroups {
+    id exampleGroup = [[KWExampleGroupBuilder sharedExampleGroupBuilder] buildExampleGroups:^{}];
     STAssertNotNil(exampleGroup, @"expected example group to be created");
     STAssertFalse([[KWExampleGroupBuilder sharedExampleGroupBuilder] isBuildingExampleGroup], @"example group builder must be clean for other tests to run cleanly");
 }
 
-- (void)testItShouldRaiseIfStartExampleGroupIsUnmatched {
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] startExampleGroups];
-    STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] startExampleGroups], @"expected raised exception");
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups];
-    STAssertFalse([[KWExampleGroupBuilder sharedExampleGroupBuilder] isBuildingExampleGroup], @"example group builder must be clean for other tests to run cleanly");
-}
-
-- (void)testItShouldRaiseIfEndExampleGroupIsUnmatched {
-    STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups], @"expected raised exception");
+- (void)testItShouldRaiseIfBuildingIsNested {
+  [[KWExampleGroupBuilder sharedExampleGroupBuilder] buildExampleGroups:^{
+      STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] buildExampleGroups:^{}], @"expected raised exception");
+  }];
     STAssertFalse([[KWExampleGroupBuilder sharedExampleGroupBuilder] isBuildingExampleGroup], @"example group builder must be clean for other tests to run cleanly");
 }
 
 - (void)testItShouldRaiseWhenEndingWithPushContextUnmatched {
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] startExampleGroups];
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] pushContextNodeWithCallSite:nil description:@"Cruiser"];
-    STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups], @"expected raised exception");
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] popContextNode];
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups];
+    STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] buildExampleGroups:^{
+        [[KWExampleGroupBuilder sharedExampleGroupBuilder] pushContextNodeWithCallSite:nil description:@"Cruiser"];
+    }], @"expected raised exception");
     STAssertFalse([[KWExampleGroupBuilder sharedExampleGroupBuilder] isBuildingExampleGroup], @"example group builder must be clean for other tests to run cleanly");
 }
 
 - (void)testItShouldRaiseWhenPopContextUnmatched {
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] startExampleGroups];
-    STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] popContextNode], @"expected raised exception");
-    [[KWExampleGroupBuilder sharedExampleGroupBuilder] endExampleGroups];
+    [[KWExampleGroupBuilder sharedExampleGroupBuilder] buildExampleGroups:^{
+        STAssertThrows([[KWExampleGroupBuilder sharedExampleGroupBuilder] popContextNode], @"expected raised exception");
+    }];
     STAssertFalse([[KWExampleGroupBuilder sharedExampleGroupBuilder] isBuildingExampleGroup], @"example group builder must be clean for other tests to run cleanly");
 }
 


### PR DESCRIPTION
I fixed the tests that were broken in commit 81e45b001ee921a6797733b9a97687c705cf98a6, along with the method that tests if we are in the simulator or not.

(this fixes issue #74)
