### PR TITLE
Fix some type errors that don't manifest on iOS

### DIFF
--- a/Kiwi/KWFailure.m
+++ b/Kiwi/KWFailure.m
@@ -56,7 +56,7 @@
 #pragma mark Getting Exception Representations
 
 - (NSException *)exceptionValue {
-    NSNumber *lineNumber = [NSNumber numberWithUnsignedInt:self.callSite.lineNumber];
+    NSNumber *lineNumber = [NSNumber numberWithUnsignedInteger:self.callSite.lineNumber];
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:self.callSite.filename, SenTestFilenameKey,
                                                                         lineNumber, SenTestLineNumberKey, nil];
     return [NSException exceptionWithName:@"KWFailureException" reason:message userInfo:userInfo];

--- a/Kiwi/KWHaveMatcher.m
+++ b/Kiwi/KWHaveMatcher.m
@@ -213,8 +213,8 @@ static NSString * const CountKey = @"CountKey";
 + (void)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer didCaptureInvocation:(NSInvocation *)anInvocation {
     NSDictionary *userInfo = anInvocationCapturer.userInfo;
     id verifier = [userInfo objectForKey:MatchVerifierKey];
-    KWCountType countType = [[userInfo objectForKey:CountTypeKey] unsignedIntValue];
-    KWCountType count = [[userInfo objectForKey:CountKey] unsignedIntValue];
+    KWCountType countType = [[userInfo objectForKey:CountTypeKey] unsignedIntegerValue];
+    NSUInteger count = [[userInfo objectForKey:CountKey] unsignedIntegerValue];
 
     switch (countType) {
         case KWCountTypeExact:
@@ -240,8 +240,8 @@ static NSString * const CountKey = @"CountKey";
 
 - (NSDictionary *)userInfoForHaveMatcherWithCountType:(KWCountType)aCountType count:(NSUInteger)aCount {
     return [NSDictionary dictionaryWithObjectsAndKeys:self, MatchVerifierKey,
-                                                      [NSNumber numberWithUnsignedInt:aCountType], CountTypeKey,
-                                                      [NSNumber numberWithUnsignedInt:aCount], CountKey, nil];
+                                                      [NSNumber numberWithUnsignedInteger:aCountType], CountTypeKey,
+                                                      [NSNumber numberWithUnsignedInteger:aCount], CountKey, nil];
 }
 
 - (id)have:(NSUInteger)aCount {

--- a/Kiwi/KWReceiveMatcher.m
+++ b/Kiwi/KWReceiveMatcher.m
@@ -188,8 +188,8 @@ static NSString * const StubValueKey = @"StubValueKey";
 + (void)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer didCaptureInvocation:(NSInvocation *)anInvocation {
     NSDictionary *userInfo = anInvocationCapturer.userInfo;
     id verifier = [userInfo objectForKey:MatchVerifierKey];
-    KWCountType countType = [[userInfo objectForKey:CountTypeKey] unsignedIntValue];
-    NSUInteger count = [[userInfo objectForKey:CountKey] unsignedIntValue];
+    KWCountType countType = [[userInfo objectForKey:CountTypeKey] unsignedIntegerValue];
+    NSUInteger count = [[userInfo objectForKey:CountKey] unsignedIntegerValue];
     NSValue *stubValue = [userInfo objectForKey:StubValueKey];
     KWMessagePattern *messagePattern = [KWMessagePattern messagePatternFromInvocation:anInvocation];
 
@@ -266,14 +266,14 @@ static NSString * const StubValueKey = @"StubValueKey";
 
 - (NSDictionary *)userInfoForReceiveMatcherWithCountType:(KWCountType)aCountType count:(NSUInteger)aCount {
     return [NSDictionary dictionaryWithObjectsAndKeys:self, MatchVerifierKey,
-                                                      [NSNumber numberWithUnsignedInt:aCountType], CountTypeKey,
-                                                      [NSNumber numberWithUnsignedInt:aCount], CountKey, nil];
+                                                      [NSNumber numberWithUnsignedInteger:aCountType], CountTypeKey,
+                                                      [NSNumber numberWithUnsignedInteger:aCount], CountKey, nil];
 }
 
 - (NSDictionary *)userInfoForReceiveMatcherWithCountType:(KWCountType)aCountType count:(NSUInteger)aCount value:(id)aValue {
     return [NSDictionary dictionaryWithObjectsAndKeys:self, MatchVerifierKey,
-                                                      [NSNumber numberWithUnsignedInt:aCountType], CountTypeKey,
-                                                      [NSNumber numberWithUnsignedInt:aCount], CountKey,
+                                                      [NSNumber numberWithUnsignedInteger:aCountType], CountTypeKey,
+                                                      [NSNumber numberWithUnsignedInteger:aCount], CountKey,
                                                       [NSValue valueWithNonretainedObject:aValue], StubValueKey, nil];
 }
 


### PR DESCRIPTION
I've taken a look at porting Kiwi to OS X. The first thing that crops up are some compiler/warnings errors. There are places where an NSInteger is used, but it's being stored into an NSNumber as an int, which isn't a problem on iOS because NSIntegers are ints on 32-bit systems. However building for a 64-bit machine, they are longs. I've switched the NSNumber instances to use the integer methods for loading and storing, eliminating the build errors.

Although these commits wouldn't actually affect performance on iOS, it does add consistency.
