### PR TITLE
Add contains support to NSSet and NSOrderedSet

### DIFF
--- a/Kiwi/KWHamrestMatchingAdditions.h
+++ b/Kiwi/KWHamrestMatchingAdditions.h
@@ -23,3 +23,14 @@
 
 @end
 
+@interface NSSet (KiwiHamcrestAdditions)
+
+- (BOOL)containsObjectEqualToOrMatching:(id)object;
+
+@end
+
+@interface NSOrderedSet (KiwiHamcrestAdditions)
+
+- (BOOL)containsObjectEqualToOrMatching:(id)object;
+
+@end

--- a/Kiwi/KWHamrestMatchingAdditions.m
+++ b/Kiwi/KWHamrestMatchingAdditions.m
@@ -46,4 +46,28 @@
 
 @end
 
+@implementation NSSet (KiwiHamcrestAdditions)
+
+- (BOOL)containsObjectEqualToOrMatching:(id)object
+{
+    if ([object conformsToProtocol:@protocol(HCMatcher)]) {
+        return [[self allObjects] containsObjectMatching:object];
+    }
+    return [self containsObject:object];
+}
+
+@end
+
+@implementation NSOrderedSet (KiwiHamcrestAdditions)
+
+- (BOOL)containsObjectEqualToOrMatching:(id)object
+{
+    if ([object conformsToProtocol:@protocol(HCMatcher)]) {
+        return [[self array] containsObjectMatching:object];
+    }
+    return [self containsObject:object];
+}
+
+@end
+
 


### PR DESCRIPTION
Currently only NSArray supports the [[container should] contain:object] assertion. This commit adds the same support to NSSet and NSOrderedSet.
