### PR TITLE
XCode reports description of examples and a yellow warning for pending

### DIFF
--- a/Kiwi/KWExample.h
+++ b/Kiwi/KWExample.h
@@ -49,6 +49,11 @@
 
 - (BOOL)isLastInContext:(KWContextNode *)context;
 
+#pragma mark -
+#pragma mark Full description with context
+
+- (NSString *)descriptionWithContext;
+
 @end
 
 #pragma mark -

--- a/Kiwi/KWExample.m
+++ b/Kiwi/KWExample.m
@@ -31,6 +31,7 @@
 @property (nonatomic, readonly) NSMutableArray *verifiers;
 @property (nonatomic, readonly) KWMatcherFactory *matcherFactory;
 @property (nonatomic, assign) id<KWExampleDelegate> delegate;
+@property (nonatomic, assign) BOOL didNotFinish;
 
 - (void)reportResultForExampleNodeWithLabel:(NSString *)label;
 
@@ -43,6 +44,7 @@
 @synthesize delegate = _delegate;
 @synthesize suite;
 @synthesize lastInContext;
+@synthesize didNotFinish;
 
 - (id)initWithExampleNode:(id<KWExampleNode>)node
 {
@@ -150,6 +152,25 @@
 - (void)reportResultForExampleNodeWithLabel:(NSString *)label
 {
   NSLog(@"+ '%@ %@' [%@]", [self descriptionForExampleContext], [exampleNode description], label);
+}
+
+#pragma mark - Full description with context
+
+/** Pending cases will be marked yellow by XCode as not finished, because their description differs for -[SenTestCaseRun start] and -[SenTestCaseRun stop] methods
+ */
+
+- (NSString *)pendingNotFinished {
+    BOOL reportPending = self.didNotFinish;
+    self.didNotFinish = YES;
+    return reportPending ? @"(PENDING)" : @"";
+}
+    
+- (NSString *)descriptionWithContext {
+    NSString *descriptionWithContext = [NSString stringWithFormat:@"%@ %@", 
+                                        [self descriptionForExampleContext], 
+                                        [exampleNode description] ? [exampleNode description] : @""];
+    BOOL isPending = [exampleNode isKindOfClass:[KWPendingNode class]];
+    return isPending ? [descriptionWithContext stringByAppendingString:[self pendingNotFinished]] : descriptionWithContext;
 }
 
 #pragma mark - Visiting Nodes

--- a/Kiwi/KWSpec.m
+++ b/Kiwi/KWSpec.m
@@ -39,9 +39,16 @@
 
 + (void)buildExampleGroups {}
 
+/* Reported by XCode SenTestingKit Runner before and after invocation of the test
+   Use underscore _ to make method friendly names from example description
+ */
+
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"-[%@ example]", NSStringFromClass([self class])];
+    KWExample *currentExample = self.example ? self.example : [[self invocation] kw_example];
+    NSString *name = [currentExample descriptionWithContext];
+    name = [name stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+    return [NSString stringWithFormat:@"-[%@ %@]", NSStringFromClass([self class]), name];
 }
 
 #pragma mark -


### PR DESCRIPTION
Pending cases are now reported by XCode as yellow warning: not finished
#67 Warnings (yellow) for "pending" tests

Examples are now shown with full description using underscore instead of spaces
#69 "Run test case example" instead of meaningful description?

The XML output can now be generated by https://github.com/ciryon/OCUnit2JUnit
#84 JUnit-compatable XML output.
