### PR TITLE
Fixing a crash when stubbing and spying on an object at the same time.

### DIFF
--- a/Kiwi/KWExample.m
+++ b/Kiwi/KWExample.m
@@ -241,8 +241,7 @@
     }
     
     // Always clear stubs and spies at the end of it blocks
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+      KWClearStubsAndSpies();
   }];
 }
 

--- a/Kiwi/KWIntercept.h
+++ b/Kiwi/KWIntercept.h
@@ -32,6 +32,9 @@ Class KWRealClassForClass(Class aClass);
 Class KWSetupObjectInterceptSupport(id anObject);
 void KWSetupMethodInterceptSupport(Class interceptClass, SEL aSelector);
 
+#pragma mark - Managing Stubs & Spies
+void KWClearStubsAndSpies(void);
+
 #pragma mark -
 #pragma mark Managing Objects Stubs
 

--- a/Kiwi/KWIntercept.m
+++ b/Kiwi/KWIntercept.m
@@ -12,6 +12,7 @@
 static const char * const KWInterceptClassSuffix = "_KWIntercept";
 static NSMutableDictionary *KWObjectStubs = nil;
 static NSMutableDictionary *KWMessageSpies = nil;
+static NSMutableArray *KWRestoredObjects = nil;
 
 #pragma mark -
 #pragma mark Intercept Enabled Method Implementations
@@ -212,6 +213,15 @@ Class KWInterceptedSuperclass(id anObject, SEL aSelector) {
     return originalSuperclass;
 }
 
+#pragma mark - Managing Stubs & Spies
+
+void KWClearStubsAndSpies(void) {
+    KWRestoredObjects = [NSMutableArray array];
+    KWClearAllMessageSpies();
+    KWClearAllObjectStubs();
+    KWRestoredObjects = nil;
+}
+
 #pragma mark -
 #pragma mark Managing Objects Stubs
 
@@ -250,7 +260,11 @@ void KWClearObjectStubs(id anObject) {
 void KWClearAllObjectStubs(void) {
     for (NSValue *objectKey in KWObjectStubs) {
         id stubbedObject = [objectKey nonretainedObjectValue];
+        if ([KWRestoredObjects containsObject:stubbedObject]) {
+            continue;
+        }
         KWRestoreOriginalClass(stubbedObject);
+        [KWRestoredObjects addObject:stubbedObject];
     }
     [KWObjectStubs removeAllObjects];
 }
@@ -298,7 +312,11 @@ void KWClearObjectSpy(id anObject, id aSpy, KWMessagePattern *aMessagePattern) {
 void KWClearAllMessageSpies(void) {
     for (NSValue *objectKey in KWMessageSpies) {
         id spiedObject = [objectKey nonretainedObjectValue];
+        if ([KWRestoredObjects containsObject:spiedObject]) {
+            continue;
+        }
         KWRestoreOriginalClass(spiedObject);
+        [KWRestoredObjects addObject:spiedObject];
     }
     [KWMessageSpies removeAllObjects];
 }

--- a/Kiwi/KWTestCase.m
+++ b/Kiwi/KWTestCase.m
@@ -67,8 +67,7 @@
 }
 
 - (void)tearDownExampleEnvironment {
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+    KWClearStubsAndSpies();
 }
 
 #pragma mark -

--- a/Tests/KWMockTest.m
+++ b/Tests/KWMockTest.m
@@ -19,8 +19,7 @@
 @implementation KWMockTest
 
 - (void)tearDown {
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+    KWClearStubsAndSpies();
 }
 
 - (void)testItShouldInitializeForAClassWithANameAsANullObject {
@@ -62,8 +61,7 @@
     KWMessagePattern *firstMessagePattern = [KWMessagePattern messagePatternWithSelector:@selector(notifyEarth)];
     [[Galaxy sharedGalaxy] addMessageSpy:firstSpy forMessagePattern:firstMessagePattern];
     
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+    KWClearStubsAndSpies();
     
     TestSpy *secondSpy = [TestSpy testSpy];
     KWMessagePattern *secondMessagePattern = [KWMessagePattern messagePatternWithSelector:@selector(notifyPlanet:)];

--- a/Tests/KWRealObjectSpyTest.m
+++ b/Tests/KWRealObjectSpyTest.m
@@ -18,8 +18,7 @@
 @implementation KWRealObjectSpyTest
 
 - (void)tearDown {
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+    KWClearStubsAndSpies();
 }
 
 - (void)testItShouldNotifySpies {

--- a/Tests/KWRealObjectStubTest.m
+++ b/Tests/KWRealObjectStubTest.m
@@ -18,8 +18,7 @@
 @implementation KWRealObjectStubTest
 
 - (void)tearDown {
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+    KWClearStubsAndSpies();
 }
 
 - (void)testItShouldRaiseWhenStubbingNonExistentMethods {

--- a/Tests/KWStubTest.m
+++ b/Tests/KWStubTest.m
@@ -19,8 +19,7 @@
 @implementation KWStubTest
 
 - (void)tearDown {
-    KWClearAllMessageSpies();
-    KWClearAllObjectStubs();
+    KWClearStubsAndSpies();
 }
 
 - (void)testItShouldProcessMatchedInvocations {


### PR DESCRIPTION
Pull request #114 produces a crash when stubbing and spying class methods.

For example the two lines

`[NSDate stub:@selector(dateWithTimeIntervalSince1970:) andReturn:nil];
[[NSDate should] receive:@selector(dateWithTimeIntervalSince1970:) withArguments:any()]`

both work on their own. However, when both are used in the same it-block the test crashes with `handler threw exception`.

http://cl.ly/3S042q3d3E0o1L1j2w43

Of course, this also breaks the shorthand method 

```
[[NSDate should] receive:@selector(dateWithTimeIntervalSince1970:) andReturn:nil withArguments:any()];
```

The problem is that when an object is in `KWObjectStubs` and `KWMessageSpies` `KWRestoreOriginalClass()` gets called twice for that object which leads to the crash.

My solution wraps the tearDown calls `KWClearAllMessageSpies()` and `KWClearAllObjectStubs()` in a new call `KWClearStubsAndSpies()` which makes sure that each object only gets restored to their original class once.
