### PR TITLE
Fix spec description

### DIFF
--- a/Kiwi/KWSpec.m
+++ b/Kiwi/KWSpec.m
@@ -64,10 +64,9 @@
     name = [name stringByReplacingOccurrencesOfString:@"," withString:@"_"];
     
     // Strip out characters not legal in function names
-    NSMutableCharacterSet *illegalCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
-    [illegalCharacters addCharactersInString:@"_()"];
-    [illegalCharacters invert];
-    name = [[name componentsSeparatedByCharactersInSet:illegalCharacters] componentsJoinedByString:@""];
+    NSError *error = nil;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^a-zA-Z0-9_]*" options:0 error:&error];
+    name = [regex stringByReplacingMatchesInString:name options:0 range:NSMakeRange(0, name.length) withTemplate:@""];
 
     return [NSString stringWithFormat:@"-[%@ %@]", NSStringFromClass([self class]), name];
 }


### PR DESCRIPTION
If the description of 'describe', 'context', or 'it' contains multibyte characters(I wrote Japanese) or '(', ')' , Test Runner doesn't show errors even if the example failed.

I used NSRegularExpression instead of NSMutableCharacterSet to fix it. Because, 
- [NSMutableCharacterSet alphanumericCharacterSet] can't fiter Japanese characters and so on.
- Deployment Target is 4.0 (NSRegularExpression is available in iOS 4.0 and later).
