### PR TITLE
New project templates in Xcode 4.4 define NSUInteger differently from previous versions

### DIFF
--- a/Kiwi/KWBeEmptyMatcher.m
+++ b/Kiwi/KWBeEmptyMatcher.m
@@ -54,7 +54,7 @@
     if (self.count == 1)
         return @"1 item";
     else
-        return [NSString stringWithFormat:@"%u items", self.count];
+        return [NSString stringWithFormat:@"%u items", (unsigned)self.count];
 }
 
 - (NSString *)failureMessageForShould {

--- a/Kiwi/KWCallSite.m
+++ b/Kiwi/KWCallSite.m
@@ -39,7 +39,7 @@
 #pragma mark Identifying and Comparing
 
 - (NSUInteger)hash {
-    return [[NSString stringWithFormat:@"%@%u", self.filename, self.lineNumber] hash];
+    return [[NSString stringWithFormat:@"%@%u", self.filename, (unsigned)self.lineNumber] hash];
 }
 
 - (BOOL)isEqual:(id)anObject {

--- a/Kiwi/KWHaveMatcher.m
+++ b/Kiwi/KWHaveMatcher.m
@@ -133,13 +133,13 @@ static NSString * const CountKey = @"CountKey";
     if (self.actualCount == 1)
         return @"1 item";
     else
-        return [NSString stringWithFormat:@"%u items", self.actualCount];
+        return [NSString stringWithFormat:@"%u items", (unsigned)self.actualCount];
 }
 
 - (NSString *)failureMessageForShould {
     return [NSString stringWithFormat:@"expected subject to %@ %u %@, got %@",
                                       [self verbPhrase],
-                                      self.count,
+                                      (unsigned)self.count,
                                       [self itemPhrase],
                                       [self actualCountPhrase]];
 }
@@ -147,7 +147,7 @@ static NSString * const CountKey = @"CountKey";
 - (NSString *)failureMessageForShouldNot {
     return [NSString stringWithFormat:@"expected subject not to %@ %u %@",
                                       [self verbPhrase],
-                                      self.count,
+                                      (unsigned)self.count,
                                       [self itemPhrase]];
 }
 
@@ -156,7 +156,7 @@ static NSString * const CountKey = @"CountKey";
 
 - (NSString *)description
 {
-  return [NSString stringWithFormat:@"%@ %u %@", [self verbPhrase], self.count, [self itemPhrase]];
+  return [NSString stringWithFormat:@"%@ %u %@", [self verbPhrase], (unsigned)self.count, [self itemPhrase]];
 }
 
 #pragma mark -

--- a/Kiwi/KWIntercept.m
+++ b/Kiwi/KWIntercept.m
@@ -162,7 +162,8 @@ Class KWRestoreOriginalClass(id anObject) {
     if (KWClassIsInterceptClass(interceptClass))
     {
         Class originalClass = class_getSuperclass(interceptClass);
-        anObject->isa = originalClass;
+        // anObject->isa = originalClass;
+        object_setClass(anObject, originalClass);
     }
     return interceptClass;
 }
@@ -191,7 +192,8 @@ void KWInterceptedForwardInvocation(id anObject, SEL aSelector, NSInvocation* an
 
     Class interceptClass = KWRestoreOriginalClass(anObject);
     [anInvocation invoke];
-    anObject->isa = interceptClass;
+    // anObject->isa = interceptClass;
+    object_setClass(anObject, interceptClass);
 }
 
 void KWInterceptedDealloc(id anObject, SEL aSelector) {

--- a/Kiwi/KWMatcherFactory.m
+++ b/Kiwi/KWMatcherFactory.m
@@ -73,8 +73,10 @@
         Class *classes = malloc(sizeof(Class) * numberOfClasses);
         numberOfClasses = objc_getClassList(classes, numberOfClasses);
 
-        if (numberOfClasses == 0)
+        if (numberOfClasses == 0) {
+            free(classes);
             return;
+        }
 
         for (int i = 0; i < numberOfClasses; ++i) {
             Class candidateClass = classes[i];

--- a/Kiwi/KWMessageTracker.m
+++ b/Kiwi/KWMessageTracker.m
@@ -96,7 +96,7 @@
     if (aCount == 1)
         return @"1 time";
 
-    return [NSString stringWithFormat:@"%d times", aCount];
+    return [NSString stringWithFormat:@"%d times", (int)aCount];
 }
 
 - (NSString *)expectedCountPhrase {
@@ -144,8 +144,8 @@
     return [NSString stringWithFormat:@"messagePattern: %@\nmode: %@\ncount: %d\nreceiveCount: %d",
                                       self.messagePattern,
                                       self.modeString,
-                                      self.count,
-                                      self.receivedCount];
+                                      (int)self.count,
+                                      (int)self.receivedCount];
 }
 
 @end


### PR DESCRIPTION
I added (int) and (unsigned) operators to arguments that now can be safely formatted using %d and %u modifiers.
