### PR TITLE
Frameworks location does not exist anymore

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/allending/Kiwi.git', :tag => 'v1.0.0' }
   s.source_files = 'Kiwi'
   s.framework    = 'SenTestingKit'
-  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
   s.clean_paths  = ["Examples", "Classes", "*.xcodeproj", "Other Sources", "Resources", "Templates", "Tests", "*.sh"]
 end


### PR DESCRIPTION
`"$(SDKROOT)/Developer/Library/Frameworks"` generates a warning in Xcode 4.3.2. It says that the location doesn't exists anymore. Maybe this is obsolete and can be deleted. I have not tested it on other machines. SenTestingKit is found in `"$(DEVELOPER_LIBRARY_DIR)/Frameworks"` without problems as I posted here: https://github.com/CocoaPods/Specs/commit/c5d3761a3b7e0fa2bc032f6729bc2467d81e9e54.

Here is the warning:

```
ld: warning: directory not found for option '-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/Developer/Library/Frameworks'
```
