### PR TITLE
fix OCHamcrest integration

### DIFF
--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		19A62264151B899D00207192 /* Galaxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 19A62263151B899C00207192 /* Galaxy.m */; };
 		4B45D6BD1548765800793B1E /* KWCaptureSpy.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B45D6BB1548765800793B1E /* KWCaptureSpy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4B45D6BE1548765800793B1E /* KWCaptureSpy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B45D6BC1548765800793B1E /* KWCaptureSpy.m */; };
+		4B5F433B1575EEE8009A432F /* KWHamcrestDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B5F433A1575EEE8009A432F /* KWHamcrestDetector.m */; };
 		4B9D040814D3EE7300707E83 /* KWExampleGroupDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A3758CDA1418CDC10051268A /* KWExampleGroupDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4BA52D0115487F0C00FC957B /* KWCaptureTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BA52D0015487F0C00FC957B /* KWCaptureTest.m */; };
 		637FFB2A150513D500DBFE8F /* KWBeSubclassOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 637FFB28150513D500DBFE8F /* KWBeSubclassOfClassMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -624,6 +625,7 @@
 		32CA4F630368D1EE00C91783 /* Kiwi_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Kiwi_Prefix.pch; sourceTree = "<group>"; };
 		4B45D6BB1548765800793B1E /* KWCaptureSpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWCaptureSpy.h; sourceTree = "<group>"; };
 		4B45D6BC1548765800793B1E /* KWCaptureSpy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWCaptureSpy.m; sourceTree = "<group>"; };
+		4B5F433A1575EEE8009A432F /* KWHamcrestDetector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWHamcrestDetector.m; sourceTree = "<group>"; };
 		4BA52D0015487F0C00FC957B /* KWCaptureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWCaptureTest.m; sourceTree = "<group>"; };
 		637FFB28150513D500DBFE8F /* KWBeSubclassOfClassMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWBeSubclassOfClassMatcher.h; sourceTree = "<group>"; };
 		637FFB29150513D500DBFE8F /* KWBeSubclassOfClassMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWBeSubclassOfClassMatcher.m; sourceTree = "<group>"; };
@@ -953,8 +955,10 @@
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
+			indentWidth = 2;
 			name = CustomTemplate;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;
@@ -1115,10 +1119,6 @@
 				A352EA1812EDC8160049C691 /* KWHamcrestMatcher.m */,
 				A385CAE913AA7ED800DCA951 /* KWUserDefinedMatcher.h */,
 				A385CAEA13AA7ED800DCA951 /* KWUserDefinedMatcher.m */,
-				A3A1754212E496CA004DFD70 /* KWStringPrefixMatcher.h */,
-				A3A1754312E496CA004DFD70 /* KWStringPrefixMatcher.m */,
-				C922D1D71580438300995B43 /* KWStringContainsMatcher.h */,
-				C922D1D81580438300995B43 /* KWStringContainsMatcher.m */,
 				A385CAED13AAC9B600DCA951 /* KWMatchers.h */,
 				A385CAEE13AAC9B700DCA951 /* KWMatchers.m */,
 			);
@@ -1187,8 +1187,13 @@
 				F50922FB1165E43D00083EB1 /* NSValue+KiwiAdditions.h */,
 				F50922FC1165E43D00083EB1 /* NSValue+KiwiAdditions.m */,
 				A3A1753E12E49505004DFD70 /* KWHCMatcher.h */,
+				4B5F433A1575EEE8009A432F /* KWHamcrestDetector.m */,
 				A352EA0C12EDC6F20049C691 /* KWHamrestMatchingAdditions.h */,
 				A352EA0D12EDC6F20049C691 /* KWHamrestMatchingAdditions.m */,
+				A3A1754212E496CA004DFD70 /* KWStringPrefixMatcher.h */,
+				A3A1754312E496CA004DFD70 /* KWStringPrefixMatcher.m */,
+				C922D1D71580438300995B43 /* KWStringContainsMatcher.h */,
+				C922D1D81580438300995B43 /* KWStringContainsMatcher.m */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -1880,6 +1885,7 @@
 				4B45D6BE1548765800793B1E /* KWCaptureSpy.m in Sources */,
 				C922D1DA1580438300995B43 /* KWStringContainsMatcher.m in Sources */,
 				C922D1E715805ADB00995B43 /* KWStringPrefixMatcher.m in Sources */,
+				4B5F433B1575EEE8009A432F /* KWHamcrestDetector.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Kiwi/KWExample.h
+++ b/Kiwi/KWExample.h
@@ -86,6 +86,11 @@ void pendingWithCallSite(KWCallSite *aCallSite, NSString *aDescription, KWVoidBl
 #define pending(title, args...) \
 PENDING(title) \
 pending_(title, ## args)
+
 #define xit(title, args...) \
+PENDING(title) \
+pending_(title, ## args)
+
+#define xcontext(title, args...) \
 PENDING(title) \
 pending_(title, ## args)

--- a/Kiwi/KWExample.m
+++ b/Kiwi/KWExample.m
@@ -31,7 +31,6 @@
 @property (nonatomic, readonly) NSMutableArray *verifiers;
 @property (nonatomic, readonly) KWMatcherFactory *matcherFactory;
 @property (nonatomic, assign) id<KWExampleDelegate> delegate;
-@property (nonatomic, assign) BOOL didNotFinish;
 
 - (void)reportResultForExampleNodeWithLabel:(NSString *)label;
 
@@ -44,7 +43,6 @@
 @synthesize delegate = _delegate;
 @synthesize suite;
 @synthesize lastInContext;
-@synthesize didNotFinish;
 
 - (id)initWithExampleNode:(id<KWExampleNode>)node
 {
@@ -117,14 +115,14 @@
 
 - (NSString *)descriptionForExampleContext {
   NSMutableArray *parts = [NSMutableArray array];
-
+  
   for (KWContextNode *context in [[exampleNode contextStack] reverseObjectEnumerator]) {
-    if ([context description] != nil) {
-      [parts addObject:[[context description] stringByAppendingString:@","]];
+    if ([context description]) {
+      [parts addObject:[context description]];
     }
   }
   
-  return [parts componentsJoinedByString:@" "];
+  return [parts componentsJoinedByString:@", "];
 }
 
 - (KWFailure *)outputReadyFailureWithFailure:(KWFailure *)aFailure {
@@ -156,21 +154,12 @@
 
 #pragma mark - Full description with context
 
-/** Pending cases will be marked yellow by XCode as not finished, because their description differs for -[SenTestCaseRun start] and -[SenTestCaseRun stop] methods
- */
-
-- (NSString *)pendingNotFinished {
-    BOOL reportPending = self.didNotFinish;
-    self.didNotFinish = YES;
-    return reportPending ? @"(PENDING)" : @"";
-}
-    
 - (NSString *)descriptionWithContext {
-    NSString *descriptionWithContext = [NSString stringWithFormat:@"%@ %@", 
-                                        [self descriptionForExampleContext], 
-                                        [exampleNode description] ? [exampleNode description] : @""];
-    BOOL isPending = [exampleNode isKindOfClass:[KWPendingNode class]];
-    return isPending ? [descriptionWithContext stringByAppendingString:[self pendingNotFinished]] : descriptionWithContext;
+  NSString *node = [exampleNode description];
+  NSString *context = [self descriptionForExampleContext];
+  NSString *description = node ? [NSString stringWithFormat:@"%@ %@", context, node] : context;
+  BOOL isPending = [exampleNode isKindOfClass:[KWPendingNode class]];
+  return isPending ? [description stringByAppendingString:@"(PENDING)"] : description;
 }
 
 #pragma mark - Visiting Nodes

--- a/Kiwi/KWHCMatcher.h
+++ b/Kiwi/KWHCMatcher.h
@@ -7,6 +7,11 @@
 
 #import <Foundation/Foundation.h>
 
+// Use HCMatcher protocol definition from Hamcrest library when available
+#if !defined(HC_assertThat) 
+
 @protocol HCMatcher <NSObject>
 - (BOOL)matches:(id)item;
 @end
+
+#endif

--- a/Kiwi/KWHamcrestDetector.m
+++ b/Kiwi/KWHamcrestDetector.m
@@ -1,0 +1,44 @@
+//
+//  KWHamcrestDetector.m
+//  Kiwi
+//
+//  Created by Paul Zabelin on 5/29/12.
+//  Copyright (c) 2012 Blazing Cloud Inc. All rights reserved.
+//
+
+/** 
+ *   NOTE: 
+ *       To use Hamcrest library with Kiwi include Hamcrest headers first in your specs
+ *       to use proper HCMatcher protocol definition instead of minimal version:
+ *
+ *       #import <OCHamcrestIOS/OCHamcrestIOS.h>
+ *       #import "Kiwi.h"
+ * 
+ *       Also link OCHamcrestIOS framework first to the test binary, prior to Kiwi library. 
+ *       XCode can set build order for the target in the build phases tab.
+ *
+ *       Failure to do so might cause endless recursion in -[HCBaseDescription appendDescriptionOf:] as it checks if
+ *       a HCMatcher conforms to HCSelfDescribing protocol, which is not the case in minimal version of HCMatcher.
+ */
+
+#import <objc/runtime.h>
+#import <Foundation/Foundation.h>
+
+#import "KWHCMatcher.h"
+
+@interface KWHamcrestDetector : NSObject
+@end
+
+@implementation KWHamcrestDetector
+
++ (void)initialize {
+    Protocol *hamcrestSelfDescribingProtocol = NSProtocolFromString(@"HCSelfDescribing");
+    if (hamcrestSelfDescribingProtocol) {
+        NSAssert(protocol_conformsToProtocol(@protocol(HCMatcher), 
+                                             hamcrestSelfDescribingProtocol), 
+                 @"HCMatcher should be loaded from Hamcrest not Kiwi, \
+                 please change link order to link Hamcrest prior to Kiwi");
+    }
+}
+
+@end

--- a/Kiwi/KWHamcrestMatcher.m
+++ b/Kiwi/KWHamcrestMatcher.m
@@ -14,17 +14,17 @@
 #pragma mark -
 #pragma mark Properties
 
-@property (nonatomic, retain) id<HCMatcher> matcher;
+@property (nonatomic, retain) id<HCMatcher> hamcrestMatcher;
 
 @end
 
 @implementation KWHamcrestMatcher
 
-@synthesize matcher;
+@synthesize hamcrestMatcher;
 
 - (void)dealloc
 {
-  [matcher release];
+  [hamcrestMatcher release];
   [super dealloc];
 }
 
@@ -32,16 +32,16 @@
 #pragma mark Matching
 
 - (BOOL)evaluate {
-    return [self.matcher matches:self.subject];
+    return [self.hamcrestMatcher matches:self.subject];
 }
 
 - (NSString *)failureMessageForShould {
-  return [NSString stringWithFormat:@"expected subject to match %@", self.matcher];
+  return [NSString stringWithFormat:@"expected %@ to %@", subject, self];
 }
 
 - (NSString *)description
 {
-  return [NSString stringWithFormat:@"match %@", [self.matcher description]];
+  return [NSString stringWithFormat:@"match %@", [self.hamcrestMatcher description]];
 }
 
 #pragma mark -
@@ -56,7 +56,7 @@
 
 - (void)match:(id<HCMatcher>)aMatcher;
 {
-    self.matcher = aMatcher;
+    self.hamcrestMatcher = aMatcher;
 }
 
 @end


### PR DESCRIPTION
add xcontext to disable whole context temporarily
fix Xcode getting confused when example name is changed between start and finish
use HCMatcher from Hamcrest when available
add KWHamcrestDetector.m to detect conflict between Hamcrest and Kiwi
improve mismatch reporting for failing hamcrest matches
