### PR TITLE
Fixes Kiwi Spec Xcode Template

### DIFF
--- a/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
+++ b/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
@@ -6,7 +6,7 @@
 //  Copyright ___YEAR___ ___ORGANIZATIONNAME___. All rights reserved.
 //
 
-#import <Kiwi/Kiwi.h>
+#import "Kiwi.h"
 
 
 SPEC_BEGIN(___FILEBASENAMEASIDENTIFIER___)


### PR DESCRIPTION
I used the `install-templates.sh` script and spent a lot of time trying to figure out my header search path. It turned out that, even though the install instructions specify to use `#import "Kiwi.h"`, the template had a `#import <Kiwi/Kiwi.h>`.

I didn't notice the discrepancy and wasted some time — I think that the templates should be congruent to the [setup instructions](https://github.com/allending/Kiwi/wiki/Guide:-Up-and-Running-with-Kiwi).
