### PR TITLE
Add KWChangeMatcher which verifies count change after block call.

### DIFF
--- a/Classes/KWChangeMatcher.h
+++ b/Classes/KWChangeMatcher.h
@@ -1,0 +1,21 @@
+//
+//  KWChangeMatcher.h
+//  Kiwi
+//
+//  Copyright (c) 2013 Eloy Durán <eloy.de.enige@gmail.com>.
+//  All rights reserved.
+//
+
+#import "KWMatcher.h"
+
+typedef NSInteger (^KWChangeMatcherCountBlock)();
+
+@interface KWChangeMatcher : KWMatcher
+
+// Expect _any_ change.
+- (void)change:(KWChangeMatcherCountBlock)countBlock;
+
+// Expect changes by a specific amount.
+- (void)change:(KWChangeMatcherCountBlock)countBlock by:(NSInteger)expectedDifference;
+
+@end

--- a/Classes/KWChangeMatcher.m
+++ b/Classes/KWChangeMatcher.m
@@ -1,0 +1,84 @@
+//
+//  KWChangeMatcher.m
+//  Kiwi
+//
+//  Copyright (c) 2013 Eloy Durán <eloy.de.enige@gmail.com>.
+//  All rights reserved.
+//
+
+#import "KWChangeMatcher.h"
+#import "KWBlock.h"
+
+@interface KWChangeMatcher ()
+@property (nonatomic, copy) KWChangeMatcherCountBlock countBlock;
+@property (nonatomic, assign) BOOL anyChange;
+@property (nonatomic, assign) NSInteger expectedDifference, expectedTotal, actualTotal;
+@end
+
+@implementation KWChangeMatcher
+
+@synthesize countBlock = _countBlock;
+@synthesize anyChange = _anyChange;
+@synthesize expectedDifference = _expectedDifference;
+@synthesize expectedTotal = _expectedTotal;
+@synthesize actualTotal = _actualTotal;
+
+- (void)dealloc {
+    Block_release(_countBlock);
+    [super dealloc];
+}
+
++ (NSArray *)matcherStrings {
+    return [NSArray arrayWithObjects:@"change:by:", @"change:", nil];
+}
+
+- (NSString *)failureMessageForShould {
+    if (self.anyChange) {
+        return @"expected subject to change the count";
+    } else {
+        return [NSString stringWithFormat:@"expected subject to change the count to %d, got %d", self.expectedTotal, self.actualTotal];
+    }
+}
+
+- (NSString *)failureMessageForShouldNot {
+    if (self.anyChange) {
+        return @"expected subject to not change the count";
+    } else {
+        return [NSString stringWithFormat:@"expected subject not to change the count to %d", self.actualTotal];
+    }
+}
+
+- (NSString *)description {
+    if (self.anyChange) {
+        return @"change count";
+    } else {
+        return [NSString stringWithFormat:@"change count by %d", self.expectedDifference];
+    }
+}
+
+- (BOOL)evaluate {
+    NSInteger before = self.countBlock();
+    // Perform actual work, which is expected to change the result of countBlock.
+    [self.subject call];
+    self.actualTotal = self.countBlock();
+
+    if (self.anyChange) {
+        return before != self.actualTotal;
+    } else {
+        self.expectedTotal = before + self.expectedDifference;
+        return self.expectedTotal == self.actualTotal;
+    }
+}
+
+- (void)change:(KWChangeMatcherCountBlock)countBlock by:(NSInteger)expectedDifference {
+    self.anyChange = NO;
+    self.expectedDifference = expectedDifference;
+    self.countBlock = countBlock;
+}
+
+- (void)change:(KWChangeMatcherCountBlock)countBlock {
+    self.anyChange = YES;
+    self.countBlock = countBlock;
+}
+
+@end

--- a/Classes/Kiwi.h
+++ b/Classes/Kiwi.h
@@ -33,6 +33,7 @@ extern "C" {
 #import "KWBlockNode.h"
 #import "KWBlockRaiseMatcher.h"
 #import "KWCallSite.h"
+#import "KWChangeMatcher.h"
 #import "KWConformToProtocolMatcher.h"
 #import "KWContainMatcher.h"
 #import "KWContextNode.h"

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 
 /* Begin PBXBuildFile section */
 		4BA52D0115487F0C00FC957B /* KWCaptureTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BA52D0015487F0C00FC957B /* KWCaptureTest.m */; };
+		511901A116A95803006E7359 /* KWChangeMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 511901A016A95803006E7359 /* KWChangeMatcherTest.m */; };
+		511901A516A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
+		511901A616A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
+		511901A716A95CDE006E7359 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 511901A416A95CDE006E7359 /* KWChangeMatcher.m */; };
+		511901A816A95CDE006E7359 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 511901A416A95CDE006E7359 /* KWChangeMatcher.m */; };
 		9F982A3816A801800030A0B1 /* Carrier.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F982A1E16A801800030A0B1 /* Carrier.m */; };
 		9F982A3916A801800030A0B1 /* Cruiser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F982A2016A801800030A0B1 /* Cruiser.m */; };
 		9F982A3A16A801800030A0B1 /* Engine.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F982A2216A801800030A0B1 /* Engine.m */; };
@@ -421,6 +426,9 @@
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* Kiwi_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Kiwi_Prefix.pch; sourceTree = "<group>"; };
 		4BA52D0015487F0C00FC957B /* KWCaptureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWCaptureTest.m; sourceTree = "<group>"; };
+		511901A016A95803006E7359 /* KWChangeMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWChangeMatcherTest.m; sourceTree = "<group>"; };
+		511901A316A95CDE006E7359 /* KWChangeMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KWChangeMatcher.h; path = Classes/KWChangeMatcher.h; sourceTree = "<group>"; };
+		511901A416A95CDE006E7359 /* KWChangeMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KWChangeMatcher.m; path = Classes/KWChangeMatcher.m; sourceTree = "<group>"; };
 		6B39D95B155C9FCB003C3444 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		6B39D95E155C9FCB003C3444 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		6B39D95F155C9FCB003C3444 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -877,6 +885,8 @@
 				9F982C6816A802920030A0B1 /* KWCallSite.m */,
 				9F982C6916A802920030A0B1 /* KWCaptureSpy.h */,
 				9F982C6A16A802920030A0B1 /* KWCaptureSpy.m */,
+				511901A316A95CDE006E7359 /* KWChangeMatcher.h */,
+				511901A416A95CDE006E7359 /* KWChangeMatcher.m */,
 				9F982C6B16A802920030A0B1 /* KWConformToProtocolMatcher.h */,
 				9F982C6C16A802920030A0B1 /* KWConformToProtocolMatcher.m */,
 				9F982C6D16A802920030A0B1 /* KWContainMatcher.h */,
@@ -1066,6 +1076,7 @@
 				A352E9E712EDC30A0049C691 /* KWHaveValueMatcherTest.m */,
 				A352EA1A12EDC8380049C691 /* KWHamcrestMatcherTest.m */,
 				A385CAE713AA7EA200DCA951 /* KWUserDefinedMatcherTest.m */,
+				511901A016A95803006E7359 /* KWChangeMatcherTest.m */,
 			);
 			name = Matchers;
 			sourceTree = "<group>";
@@ -1177,6 +1188,7 @@
 				9F982E2116A802920030A0B1 /* NSObject+KiwiStubAdditions.h in Headers */,
 				9F982E2516A802920030A0B1 /* NSObject+KiwiVerifierAdditions.h in Headers */,
 				9F982E2916A802920030A0B1 /* NSValue+KiwiAdditions.h in Headers */,
+				511901A616A95CDE006E7359 /* KWChangeMatcher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1275,6 +1287,7 @@
 				9F982E2016A802920030A0B1 /* NSObject+KiwiStubAdditions.h in Headers */,
 				9F982E2416A802920030A0B1 /* NSObject+KiwiVerifierAdditions.h in Headers */,
 				9F982E2816A802920030A0B1 /* NSValue+KiwiAdditions.h in Headers */,
+				511901A516A95CDE006E7359 /* KWChangeMatcher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1519,6 +1532,7 @@
 				9F982E2316A802920030A0B1 /* NSObject+KiwiStubAdditions.m in Sources */,
 				9F982E2716A802920030A0B1 /* NSObject+KiwiVerifierAdditions.m in Sources */,
 				9F982E2B16A802920030A0B1 /* NSValue+KiwiAdditions.m in Sources */,
+				511901A816A95CDE006E7359 /* KWChangeMatcher.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1601,6 +1615,8 @@
 				9F982E2216A802920030A0B1 /* NSObject+KiwiStubAdditions.m in Sources */,
 				9F982E2616A802920030A0B1 /* NSObject+KiwiVerifierAdditions.m in Sources */,
 				9F982E2A16A802920030A0B1 /* NSValue+KiwiAdditions.m in Sources */,
+				511901A116A95803006E7359 /* KWChangeMatcherTest.m in Sources */,
+				511901A716A95CDE006E7359 /* KWChangeMatcher.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/KWChangeMatcherTest.m
+++ b/Tests/KWChangeMatcherTest.m
@@ -1,0 +1,83 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2013 Eloy Durán. All rights reserved.
+//
+
+#import "Kiwi.h"
+#import "KiwiTestConfiguration.h"
+#import "TestClasses.h"
+
+#if KW_TESTS_ENABLED
+
+@interface KWChangeMatcherTest : SenTestCase
+
+@end
+
+@implementation KWChangeMatcherTest
+
+#pragma mark - KWMatcher API
+
+- (void)testItShouldHaveTheRightMatcherStrings {
+    NSArray *matcherStrings = [KWChangeMatcher matcherStrings];
+    NSArray *expectedStrings = [NSArray arrayWithObjects:@"change:", @"change:by:", nil];
+    STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
+                         [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
+                         @"expected specific matcher strings");
+}
+
+#pragma mark - Exact changes
+
+- (void)testItShouldMatchPositiveChanges {
+    __block NSInteger value = 21;
+    id subject = theBlock(^{ value = 42; });
+    id matcher = [KWChangeMatcher matcherWithSubject:subject];
+    [matcher change:^{ return value; } by:+21];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldMatchNegativeChanges {
+    __block NSInteger value = 42;
+    id subject = theBlock(^{ value = 21; });
+    id matcher = [KWChangeMatcher matcherWithSubject:subject];
+    [matcher change:^{ return value; } by:-21];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldNotMatchUnexpectedChanges {
+    __block NSInteger value = 21;
+    id subject = theBlock(^{ value = 42; });
+    id matcher = [KWChangeMatcher matcherWithSubject:subject];
+    [matcher change:^{ return value; } by:+1];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+- (void)testItShouldNotMatchWhenExactChangeIsExpected {
+    __block NSInteger value = 42;
+    id subject = theBlock(^{ value = 42; });
+    id matcher = [KWChangeMatcher matcherWithSubject:subject];
+    [matcher change:^{ return value; } by:-21];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+#pragma mark - Any changes
+
+- (void)testItShouldMatchAnyChange {
+    __block NSInteger value = 21;
+    id subject = theBlock(^{ value = 42; });
+    id matcher = [KWChangeMatcher matcherWithSubject:subject];
+    [matcher change:^{ return value; }];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldNotMatchNoChangeWhenAnyChangeIsExpected {
+    __block NSInteger value = 42;
+    id subject = theBlock(^{ value = 42; });
+    id matcher = [KWChangeMatcher matcherWithSubject:subject];
+    [matcher change:^{ return value; }];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+@end
+
+#endif // #if KW_TESTS_ENABLED


### PR DESCRIPTION
This matcher will verify if a block of work changes a count by the expected difference. See [the  proposed addition](https://gist.github.com/4564152) to the expectations wiki for examples.

I’ve tried to match all the code styles, but I’m unsure about your policy for copyright lines.
