### PR TITLE
#190 AfterAll not called

### DIFF
--- a/Classes/KWExample.h
+++ b/Classes/KWExample.h
@@ -23,7 +23,7 @@
   id<KWExampleNode> exampleNode;
   BOOL passed;
 }
-@property (nonatomic, retain) KWContextNode *lastInContext;
+@property (nonatomic, retain, readonly) NSMutableArray *lastInContexts;
 @property (nonatomic, assign) KWExampleSuite *suite;
 
 - (id)initWithExampleNode:(id<KWExampleNode>)node;

--- a/Classes/KWExample.m
+++ b/Classes/KWExample.m
@@ -43,7 +43,7 @@
 @synthesize verifiers;
 @synthesize delegate = _delegate;
 @synthesize suite;
-@synthesize lastInContext;
+@synthesize lastInContexts;
 @synthesize didNotFinish;
 
 - (id)initWithExampleNode:(id<KWExampleNode>)node
@@ -52,6 +52,7 @@
     exampleNode = [node retain];
     matcherFactory = [[KWMatcherFactory alloc] init];
     verifiers = [[NSMutableArray alloc] init];
+    lastInContexts = [[NSMutableArray alloc] init];
     passed = YES;
   }
   return self;
@@ -59,7 +60,7 @@
 
 - (void)dealloc 
 {
-  [lastInContext release];
+  [lastInContexts release];
   [exampleNode release];
   [matcherFactory release];
   [verifiers release];
@@ -68,7 +69,12 @@
 
 - (BOOL)isLastInContext:(KWContextNode *)context
 {
-  return context == self.lastInContext;
+  for (KWContextNode *contextWhereItLast in lastInContexts) {
+    if (context == contextWhereItLast) {
+      return YES;
+    }
+  }
+  return NO;
 }
 
 - (NSString *)description

--- a/Classes/KWExampleSuite.m
+++ b/Classes/KWExampleSuite.m
@@ -42,9 +42,10 @@
 
 - (void)markLastExampleAsLastInContext:(KWContextNode *)context
 {
-	if ([examples count] > 0) {
-		[[examples objectAtIndex:examples.count-1] setLastInContext:context];
-	}
+  if ([examples count] > 0) {
+    KWExample *lastExample = (KWExample *)[examples lastObject];
+    [lastExample.lastInContexts addObject:context];
+  }
 }
 
 - (NSArray *)invocationsForTestCase;


### PR DESCRIPTION
Occurred when we make sub-context (even if parent context is "describe") like this:

```
describe {
    context {
        afterAll {}
    }
}
```

It try to find afterAll block in upper context (in this code it's describe). 
It was appeared because ivar lastInContext was setted wrongly.
