### PR TITLE
Remove nonexistent header search path

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.source          = { :git => 'https://github.com/allending/Kiwi.git', :tag => '2.0.3' }
   s.source_files    = 'Classes'
   s.framework       = 'SenTestingKit'
-  s.xcconfig        = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.ios.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.osx.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 end


### PR DESCRIPTION
`$(SDKROOT)/Developer/Library/Frameworks` does not exist in the OS X SDK.
