### PR TITLE
Updated code to modern Objective-C syntax (literals)

### DIFF
--- a/Classes/KWBeBetweenMatcher.m
+++ b/Classes/KWBeBetweenMatcher.m
@@ -38,7 +38,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"beBetween:and:", @"beInTheIntervalFrom:to:", nil];
+    return @[@"beBetween:and:", @"beInTheIntervalFrom:to:"];
 }
 
 #pragma mark -

--- a/Classes/KWBeEmptyMatcher.m
+++ b/Classes/KWBeEmptyMatcher.m
@@ -27,7 +27,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"beEmpty"];
+    return @[@"beEmpty"];
 }
 
 #pragma mark -

--- a/Classes/KWBeIdenticalToMatcher.m
+++ b/Classes/KWBeIdenticalToMatcher.m
@@ -35,7 +35,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"beIdenticalTo:"];
+    return @[@"beIdenticalTo:"];
 }
 
 #pragma mark -

--- a/Classes/KWBeKindOfClassMatcher.m
+++ b/Classes/KWBeKindOfClassMatcher.m
@@ -27,7 +27,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"beKindOfClass:"];
+    return @[@"beKindOfClass:"];
 }
 
 #pragma mark -

--- a/Classes/KWBeMemberOfClassMatcher.m
+++ b/Classes/KWBeMemberOfClassMatcher.m
@@ -27,7 +27,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"beMemberOfClass:"];
+    return @[@"beMemberOfClass:"];
 }
 
 #pragma mark -

--- a/Classes/KWBeNilMatcher.m
+++ b/Classes/KWBeNilMatcher.m
@@ -15,7 +15,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-  return [NSArray arrayWithObjects:@"beNil", nil];
+  return @[@"beNil"];
 }
 
 #pragma mark -

--- a/Classes/KWBeNonNilMatcher.m
+++ b/Classes/KWBeNonNilMatcher.m
@@ -15,7 +15,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-  return [NSArray arrayWithObjects:@"beNonNil", nil];
+  return @[@"beNonNil"];
 }
 
 #pragma mark -

--- a/Classes/KWBeSubclassOfClassMatcher.m
+++ b/Classes/KWBeSubclassOfClassMatcher.m
@@ -27,7 +27,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"beSubclassOfClass:"];
+    return @[@"beSubclassOfClass:"];
 }
 
 #pragma mark -

--- a/Classes/KWBeTrueMatcher.m
+++ b/Classes/KWBeTrueMatcher.m
@@ -26,7 +26,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"beTrue", @"beFalse", @"beYes", @"beNo", nil];
+    return @[@"beTrue", @"beFalse", @"beYes", @"beNo"];
 }
 
 #pragma mark -

--- a/Classes/KWBeWithinMatcher.m
+++ b/Classes/KWBeWithinMatcher.m
@@ -40,7 +40,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"beWithin:of:", @"equal:withDelta:", nil];
+    return @[@"beWithin:of:", @"equal:withDelta:"];
 }
 
 #pragma mark -

--- a/Classes/KWBeZeroMatcher.m
+++ b/Classes/KWBeZeroMatcher.m
@@ -14,7 +14,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"beZero"];
+    return @[@"beZero"];
 }
 
 #pragma mark -
@@ -24,7 +24,7 @@
     if (![self.subject respondsToSelector:@selector(boolValue)])
         [NSException raise:@"KWMatcherException" format:@"subject does not respond to -numberValue"];
 
-    return [[self.subject numberValue] isEqualToNumber:[NSNumber numberWithInt:0]];
+    return [[self.subject numberValue] isEqualToNumber:@0];
 }
 
 #pragma mark -

--- a/Classes/KWBlockRaiseMatcher.m
+++ b/Classes/KWBlockRaiseMatcher.m
@@ -38,10 +38,10 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"raise",
+    return @[@"raise",
                                      @"raiseWithName:",
                                      @"raiseWithReason:",
-                                     @"raiseWithName:reason:", nil];
+                                     @"raiseWithName:reason:"];
 }
 
 #pragma mark -

--- a/Classes/KWChangeMatcher.m
+++ b/Classes/KWChangeMatcher.m
@@ -29,7 +29,7 @@
 }
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"change:by:", @"change:", nil];
+    return @[@"change:by:", @"change:"];
 }
 
 - (NSString *)failureMessageForShould {

--- a/Classes/KWConformToProtocolMatcher.m
+++ b/Classes/KWConformToProtocolMatcher.m
@@ -27,7 +27,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"conformToProtocol:"];
+    return @[@"conformToProtocol:"];
 }
 
 #pragma mark -

--- a/Classes/KWContainMatcher.m
+++ b/Classes/KWContainMatcher.m
@@ -36,7 +36,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"contain:", @"containObjectsInArray:", nil];
+    return @[@"contain:", @"containObjectsInArray:"];
 }
 
 #pragma mark -
@@ -59,7 +59,7 @@
 
 - (NSString *)objectsPhrase {
     if ([self.objects count] == 1)
-        return [KWFormatter formatObject:[self.objects objectAtIndex:0]];
+        return [KWFormatter formatObject:(self.objects)[0]];
 
     return [NSString stringWithFormat:@"all of %@", [KWFormatter formatObject:self.objects]];
 }
@@ -77,7 +77,7 @@
 #pragma mark Configuring Matchers
 
 - (void)contain:(id)anObject {
-    self.objects = [NSArray arrayWithObject:anObject];
+    self.objects = @[anObject];
 }
 
 - (void)containObjectsInArray:(NSArray *)anArray {

--- a/Classes/KWEqualMatcher.m
+++ b/Classes/KWEqualMatcher.m
@@ -36,7 +36,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"equal:", nil];
+    return @[@"equal:"];
 }
 
 #pragma mark -

--- a/Classes/KWExample.m
+++ b/Classes/KWExample.m
@@ -261,7 +261,7 @@
 - (NSString *)generateDescriptionForAnonymousItNode
 {
   // anonymous specify blocks should only have one verifier, but use the first in any case
-  return [[self.verifiers objectAtIndex:0] descriptionForAnonymousItNode];
+  return [(self.verifiers)[0] descriptionForAnonymousItNode];
 }
 
 @end

--- a/Classes/KWFailure.m
+++ b/Classes/KWFailure.m
@@ -56,9 +56,9 @@
 #pragma mark Getting Exception Representations
 
 - (NSException *)exceptionValue {
-    NSNumber *lineNumber = [NSNumber numberWithUnsignedInteger:self.callSite.lineNumber];
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:self.callSite.filename, SenTestFilenameKey,
-                                                                        lineNumber, SenTestLineNumberKey, nil];
+    NSNumber *lineNumber = @(self.callSite.lineNumber);
+    NSDictionary *userInfo = @{SenTestFilenameKey: self.callSite.filename,
+                                                                        SenTestLineNumberKey: lineNumber};
     return [NSException exceptionWithName:@"KWFailureException" reason:message userInfo:userInfo];
 }
 

--- a/Classes/KWGenericMatcher.m
+++ b/Classes/KWGenericMatcher.m
@@ -48,7 +48,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-  return [NSArray arrayWithObjects:@"match:", nil];
+  return @[@"match:"];
 }
 
 #pragma mark -

--- a/Classes/KWHaveMatcher.m
+++ b/Classes/KWHaveMatcher.m
@@ -48,12 +48,12 @@ static NSString * const CountKey = @"CountKey";
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"haveCountOf:",
+    return @[@"haveCountOf:",
                                      @"haveCountOfAtLeast:",
                                      @"haveCountOfAtMost:",
                                      @"have:itemsForInvocation:",
                                      @"haveAtLeast:itemsForInvocation:",
-                                     @"haveAtMost:itemsForInvocation:", nil];
+                                     @"haveAtMost:itemsForInvocation:"];
 }
 
 #pragma mark -
@@ -199,7 +199,7 @@ static NSString * const CountKey = @"CountKey";
 #pragma mark Capturing Invocations
 
 + (NSMethodSignature *)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer methodSignatureForSelector:(SEL)aSelector {
-    KWMatchVerifier *verifier = [anInvocationCapturer.userInfo objectForKey:MatchVerifierKey];
+    KWMatchVerifier *verifier = (anInvocationCapturer.userInfo)[MatchVerifierKey];
 
     if ([verifier.subject respondsToSelector:aSelector])
         return [verifier.subject methodSignatureForSelector:aSelector];
@@ -212,9 +212,9 @@ static NSString * const CountKey = @"CountKey";
 
 + (void)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer didCaptureInvocation:(NSInvocation *)anInvocation {
     NSDictionary *userInfo = anInvocationCapturer.userInfo;
-    id verifier = [userInfo objectForKey:MatchVerifierKey];
-    KWCountType countType = [[userInfo objectForKey:CountTypeKey] unsignedIntegerValue];
-    NSUInteger count = [[userInfo objectForKey:CountKey] unsignedIntegerValue];
+    id verifier = userInfo[MatchVerifierKey];
+    KWCountType countType = [userInfo[CountTypeKey] unsignedIntegerValue];
+    NSUInteger count = [userInfo[CountKey] unsignedIntegerValue];
 
     switch (countType) {
         case KWCountTypeExact:
@@ -239,9 +239,9 @@ static NSString * const CountKey = @"CountKey";
 #pragma mark Invocation Capturing Methods
 
 - (NSDictionary *)userInfoForHaveMatcherWithCountType:(KWCountType)aCountType count:(NSUInteger)aCount {
-    return [NSDictionary dictionaryWithObjectsAndKeys:self, MatchVerifierKey,
-                                                      [NSNumber numberWithUnsignedInteger:aCountType], CountTypeKey,
-                                                      [NSNumber numberWithUnsignedInteger:aCount], CountKey, nil];
+    return @{MatchVerifierKey: self,
+                                                      CountTypeKey: @(aCountType),
+                                                      CountKey: @(aCount)};
 }
 
 - (id)have:(NSUInteger)aCount {

--- a/Classes/KWHaveValueMatcher.m
+++ b/Classes/KWHaveValueMatcher.m
@@ -40,10 +40,10 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-  return [NSArray arrayWithObjects:@"haveValue:forKey:",
+  return @[@"haveValue:forKey:",
           @"haveValueForKey:",
           @"haveValue:forKeyPath:",
-          @"haveValueForKeyPath:", nil];
+          @"haveValueForKeyPath:"];
 }
 
 #pragma mark -

--- a/Classes/KWInequalityMatcher.m
+++ b/Classes/KWInequalityMatcher.m
@@ -37,10 +37,10 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"beLessThan:",
+    return @[@"beLessThan:",
                                      @"beLessThanOrEqualTo:",
                                      @"beGreaterThan:",
-                                     @"beGreaterThanOrEqualTo:", nil];
+                                     @"beGreaterThanOrEqualTo:"];
 }
 
 #pragma mark -

--- a/Classes/KWIntercept.m
+++ b/Classes/KWIntercept.m
@@ -175,11 +175,11 @@ Class KWRestoreOriginalClass(id anObject) {
 
 void KWInterceptedForwardInvocation(id anObject, SEL aSelector, NSInvocation* anInvocation) {
     NSValue *key = [NSValue valueWithNonretainedObject:anObject];
-    NSMutableDictionary *spyArrayDictionary = [KWMessageSpies objectForKey:key];
+    NSMutableDictionary *spyArrayDictionary = KWMessageSpies[key];
 
     for (KWMessagePattern *messagePattern in spyArrayDictionary) {
         if ([messagePattern matchesInvocation:anInvocation]) {
-            NSArray *spies = [spyArrayDictionary objectForKey:messagePattern];
+            NSArray *spies = spyArrayDictionary[messagePattern];
 
             for (NSValue *spyWrapper in spies) {
                 id<KWMessageSpying> spy = [spyWrapper nonretainedObjectValue];
@@ -188,7 +188,7 @@ void KWInterceptedForwardInvocation(id anObject, SEL aSelector, NSInvocation* an
         }
     }
 
-    NSMutableArray *stubs = [KWObjectStubs objectForKey:key];
+    NSMutableArray *stubs = KWObjectStubs[key];
 
     for (KWStub *stub in stubs) {
         if ([stub processInvocation:anInvocation])
@@ -240,18 +240,18 @@ void KWAssociateObjectStub(id anObject, KWStub *aStub) {
         KWObjectStubs = [[NSMutableDictionary alloc] init];
 
     NSValue *key = [NSValue valueWithNonretainedObject:anObject];
-    NSMutableArray *stubs = [KWObjectStubs objectForKey:key];
+    NSMutableArray *stubs = KWObjectStubs[key];
 
     if (stubs == nil) {
         stubs = [[NSMutableArray alloc] init];
-        [KWObjectStubs setObject:stubs forKey:key];
+        KWObjectStubs[key] = stubs;
         [stubs release];
     }
 
     NSUInteger stubCount = [stubs count];
 
     for (NSUInteger i = 0; i < stubCount; ++i) {
-        KWStub *existingStub = [stubs objectAtIndex:i];
+        KWStub *existingStub = stubs[i];
 
         if ([aStub.messagePattern isEqualToMessagePattern:existingStub.messagePattern]) {
             [stubs removeObjectAtIndex:i];
@@ -287,19 +287,19 @@ void KWAssociateMessageSpy(id anObject, id aSpy, KWMessagePattern *aMessagePatte
         KWMessageSpies = [[NSMutableDictionary alloc] init];
 
     NSValue *key = [NSValue valueWithNonretainedObject:anObject];
-    NSMutableDictionary *spies = [KWMessageSpies objectForKey:key];
+    NSMutableDictionary *spies = KWMessageSpies[key];
 
     if (spies == nil) {
         spies = [[NSMutableDictionary alloc] init];
-        [KWMessageSpies setObject:spies forKey:key];
+        KWMessageSpies[key] = spies;
         [spies release];
     }
 
-    NSMutableArray *messagePatternSpies = [spies objectForKey:aMessagePattern];
+    NSMutableArray *messagePatternSpies = spies[aMessagePattern];
 
     if (messagePatternSpies == nil) {
         messagePatternSpies = [[NSMutableArray alloc] init];
-        [spies setObject:messagePatternSpies forKey:aMessagePattern];
+        spies[aMessagePattern] = messagePatternSpies;
         [messagePatternSpies release];
     }
 
@@ -313,8 +313,8 @@ void KWAssociateMessageSpy(id anObject, id aSpy, KWMessagePattern *aMessagePatte
 
 void KWClearObjectSpy(id anObject, id aSpy, KWMessagePattern *aMessagePattern) {
     NSValue *key = [NSValue valueWithNonretainedObject:anObject];
-    NSMutableDictionary *spyArrayDictionary = [KWMessageSpies objectForKey:key];
-    NSMutableArray *spies = [spyArrayDictionary objectForKey:aMessagePattern];
+    NSMutableDictionary *spyArrayDictionary = KWMessageSpies[key];
+    NSMutableArray *spies = spyArrayDictionary[aMessagePattern];
     NSValue *spyWrapper = [NSValue valueWithNonretainedObject:aSpy];
     [spies removeObject:spyWrapper];
 }

--- a/Classes/KWMatcherFactory.m
+++ b/Classes/KWMatcherFactory.m
@@ -50,11 +50,11 @@
     [registeredMatcherClasses addObject:aClass];
 
     for (NSString *verificationSelectorString in [aClass matcherStrings]) {
-        NSMutableArray *matcherClassChain = [matcherClassChains objectForKey:verificationSelectorString];
+        NSMutableArray *matcherClassChain = matcherClassChains[verificationSelectorString];
 
         if (matcherClassChain == nil) {
             matcherClassChain = [[NSMutableArray alloc] init];
-            [matcherClassChains setObject:matcherClassChain forKey:verificationSelectorString];
+            matcherClassChains[verificationSelectorString] = matcherClassChain;
             [matcherClassChain release];
         }
 
@@ -113,12 +113,12 @@
 #pragma mark Getting Method Signatures
 
 - (NSMethodSignature *)methodSignatureForMatcherSelector:(SEL)aSelector {
-    NSMutableArray *matcherClassChain = [matcherClassChains objectForKey:NSStringFromSelector(aSelector)];
+    NSMutableArray *matcherClassChain = matcherClassChains[NSStringFromSelector(aSelector)];
 
     if ([matcherClassChain count] == 0)
         return nil;
 
-    Class matcherClass = [matcherClassChain objectAtIndex:0];
+    Class matcherClass = matcherClassChain[0];
     return [matcherClass instanceMethodSignatureForSelector:aSelector];
 }
 
@@ -142,7 +142,7 @@
 #pragma mark Private methods
 
 - (Class)matcherClassForSelector:(SEL)aSelector subject:(id)anObject {
-    NSArray *matcherClassChain = [matcherClassChains objectForKey:NSStringFromSelector(aSelector)];
+    NSArray *matcherClassChain = matcherClassChains[NSStringFromSelector(aSelector)];
 
     for (Class matcherClass in matcherClassChain) {
         if ([matcherClass canMatchSubject:anObject])

--- a/Classes/KWMatchers.m
+++ b/Classes/KWMatchers.m
@@ -43,18 +43,18 @@ static id sharedMatchers = nil;
 - (void)defineMatcher:(NSString *)selectorString as:(KWMatchersBuildingBlock)block {
     KWUserDefinedMatcherBuilder *builder = [KWUserDefinedMatcherBuilder builderForSelector:NSSelectorFromString(selectorString)];
     block(builder);
-    [userDefinedMatchers setObject:builder forKey:builder.key];
+    userDefinedMatchers[builder.key] = builder;
 }
 
 - (void)addUserDefinedMatcherBuilder:(KWUserDefinedMatcherBuilder *)builder {
-    [userDefinedMatchers setObject:builder forKey:builder.key];
+    userDefinedMatchers[builder.key] = builder;
 }
 
 #pragma mark -
 #pragma mark Building Matchers
 
 - (KWUserDefinedMatcher *)matcherForSelector:(SEL)selector subject:(id)subject {
-    KWUserDefinedMatcherBuilder *builder = [userDefinedMatchers objectForKey:NSStringFromSelector(selector)];
+    KWUserDefinedMatcherBuilder *builder = userDefinedMatchers[NSStringFromSelector(selector)];
 
     if (builder == nil)
         return nil;

--- a/Classes/KWMessagePattern.m
+++ b/Classes/KWMessagePattern.m
@@ -131,7 +131,7 @@
         }
 
         // Match argument filter to object
-        id argumentFilter = [self.argumentFilters objectAtIndex:i];
+        id argumentFilter = (self.argumentFilters)[i];
 
         if ([argumentFilter isEqual:[KWAny any]]) {
             continue;
@@ -204,8 +204,8 @@
     NSUInteger count = [components count] - 1;
 
     for (NSUInteger i = 0; i < count; ++i) {
-        NSString *selectorComponent = [components objectAtIndex:i];
-        NSString *argumentFilterString = [KWFormatter formatObject:[self.argumentFilters objectAtIndex:i]];
+        NSString *selectorComponent = components[i];
+        NSString *argumentFilterString = [KWFormatter formatObject:(self.argumentFilters)[i]];
         [description appendFormat:@"%@:%@ ", selectorComponent, argumentFilterString];
     }
 

--- a/Classes/KWMock.m
+++ b/Classes/KWMock.m
@@ -203,7 +203,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     NSUInteger stubCount = [self.stubs count];
 
     for (NSUInteger i = 0; i < stubCount; ++i) {
-        KWStub *stub = [self.stubs objectAtIndex:i];
+        KWStub *stub = (self.stubs)[i];
 
         if ([stub.messagePattern isEqualToMessagePattern:messagePattern]) {
             [self.stubs removeObjectAtIndex:i];
@@ -242,18 +242,18 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 }
 
 - (id)stub {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:StubTag forKey:ExpectOrStubTagKey];
+    NSDictionary *userInfo = @{ExpectOrStubTagKey: StubTag};
     return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
 }
 
 - (id)stubAndReturn:(id)aValue {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:StubTag, ExpectOrStubTagKey,
-                                                                        aValue, StubValueKey, nil];
+    NSDictionary *userInfo = @{ExpectOrStubTagKey: StubTag,
+                                                                        StubValueKey: aValue};
     return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
 }
 
 - (id)stubAndReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:StubTag, ExpectOrStubTagKey, aValue, StubValueKey, times, ChangeStubValueAfterTimesKey, aSecondValue, StubSecondValueKey, nil];
+    NSDictionary *userInfo = @{ExpectOrStubTagKey: StubTag, StubValueKey: aValue, ChangeStubValueAfterTimesKey: times, StubSecondValueKey: aSecondValue};
     return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
 }
 
@@ -293,11 +293,11 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 
 - (void)addMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern {
     [self expectMessagePattern:aMessagePattern];
-    NSMutableArray *messagePatternSpies = [self.messageSpies objectForKey:aMessagePattern];
+    NSMutableArray *messagePatternSpies = (self.messageSpies)[aMessagePattern];
 
     if (messagePatternSpies == nil) {
         messagePatternSpies = [[NSMutableArray alloc] init];
-        [self.messageSpies setObject:messagePatternSpies forKey:aMessagePattern];
+        (self.messageSpies)[aMessagePattern] = messagePatternSpies;
         [messagePatternSpies release];
     }
     NSValue *spyWrapper = [NSValue valueWithNonretainedObject:aSpy];
@@ -308,7 +308,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 
 - (void)removeMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern {
     NSValue *spyWrapper = [NSValue valueWithNonretainedObject:aSpy];
-    NSMutableArray *messagePatternSpies = [self.messageSpies objectForKey:aMessagePattern];
+    NSMutableArray *messagePatternSpies = (self.messageSpies)[aMessagePattern];
     [messagePatternSpies removeObject:spyWrapper];
 }
 
@@ -328,7 +328,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 }
 
 - (id)expect {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:ExpectTag forKey:ExpectOrStubTagKey];
+    NSDictionary *userInfo = @{ExpectOrStubTagKey: ExpectTag};
     return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
 }
 
@@ -346,14 +346,14 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 
 - (void)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer didCaptureInvocation:(NSInvocation *)anInvocation {
     KWMessagePattern *messagePattern = [KWMessagePattern messagePatternFromInvocation:anInvocation];
-    NSString *tag = [anInvocationCapturer.userInfo objectForKey:ExpectOrStubTagKey];
+    NSString *tag = (anInvocationCapturer.userInfo)[ExpectOrStubTagKey];
     if ([tag isEqualToString:StubTag]) {
-        id value = [anInvocationCapturer.userInfo objectForKey:StubValueKey];
-        if (![anInvocationCapturer.userInfo objectForKey:StubSecondValueKey]) {
+        id value = (anInvocationCapturer.userInfo)[StubValueKey];
+        if (!(anInvocationCapturer.userInfo)[StubSecondValueKey]) {
             [self stubMessagePattern:messagePattern andReturn:value];
         } else {
-            id times = [anInvocationCapturer.userInfo objectForKey:ChangeStubValueAfterTimesKey];
-            id secondValue = [anInvocationCapturer.userInfo objectForKey:StubSecondValueKey];
+            id times = (anInvocationCapturer.userInfo)[ChangeStubValueAfterTimesKey];
+            id secondValue = (anInvocationCapturer.userInfo)[StubSecondValueKey];
             [self stubMessagePattern:messagePattern andReturn:value times:times afterThatReturn:secondValue];
         }
     } else {
@@ -374,7 +374,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 - (BOOL)processReceivedInvocation:(NSInvocation *)invocation {
     for (KWMessagePattern *messagePattern in self.messageSpies) {
         if ([messagePattern matchesInvocation:invocation]) {
-            NSArray *spies = [self.messageSpies objectForKey:messagePattern];
+            NSArray *spies = (self.messageSpies)[messagePattern];
 
             for (NSValue *spyWrapper in spies) {
                 id spy = [spyWrapper nonretainedObjectValue];

--- a/Classes/KWRaiseMatcher.m
+++ b/Classes/KWRaiseMatcher.m
@@ -40,10 +40,10 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"raiseWhenSent:",
+    return @[@"raiseWhenSent:",
                                      @"raiseWithName:whenSent:",
                                      @"raiseWithReason:whenSent:",
-                                     @"raiseWithName:reason:whenSent:", nil];
+                                     @"raiseWithName:reason:whenSent:"];
 }
 
 #pragma mark -

--- a/Classes/KWReceiveMatcher.m
+++ b/Classes/KWReceiveMatcher.m
@@ -56,7 +56,7 @@ static NSString * const StubValueKey = @"StubValueKey";
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObjects:@"receive:",
+    return @[@"receive:",
                                      @"receive:withCount:",
                                      @"receive:withCountAtLeast:",
                                      @"receive:withCountAtMost:",
@@ -65,7 +65,7 @@ static NSString * const StubValueKey = @"StubValueKey";
                                      @"receive:andReturn:withCountAtLeast:",
                                      @"receive:andReturn:withCountAtMost:",
                                      @"receiveMessagePattern:countType:count:",
-                                     @"receiveMessagePattern:andReturn:countType:count:", nil];
+                                     @"receiveMessagePattern:andReturn:countType:count:"];
 }
 
 #pragma mark -
@@ -176,7 +176,7 @@ static NSString * const StubValueKey = @"StubValueKey";
 #pragma mark Capturing Invocations
 
 + (NSMethodSignature *)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer methodSignatureForSelector:(SEL)aSelector {
-    KWMatchVerifier *verifier = [anInvocationCapturer.userInfo objectForKey:MatchVerifierKey];
+    KWMatchVerifier *verifier = (anInvocationCapturer.userInfo)[MatchVerifierKey];
 
     if ([verifier.subject respondsToSelector:aSelector])
         return [verifier.subject methodSignatureForSelector:aSelector];
@@ -187,10 +187,10 @@ static NSString * const StubValueKey = @"StubValueKey";
 
 + (void)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer didCaptureInvocation:(NSInvocation *)anInvocation {
     NSDictionary *userInfo = anInvocationCapturer.userInfo;
-    id verifier = [userInfo objectForKey:MatchVerifierKey];
-    KWCountType countType = [[userInfo objectForKey:CountTypeKey] unsignedIntegerValue];
-    NSUInteger count = [[userInfo objectForKey:CountKey] unsignedIntegerValue];
-    NSValue *stubValue = [userInfo objectForKey:StubValueKey];
+    id verifier = userInfo[MatchVerifierKey];
+    KWCountType countType = [userInfo[CountTypeKey] unsignedIntegerValue];
+    NSUInteger count = [userInfo[CountKey] unsignedIntegerValue];
+    NSValue *stubValue = userInfo[StubValueKey];
     KWMessagePattern *messagePattern = [KWMessagePattern messagePatternFromInvocation:anInvocation];
 
     if (stubValue != nil)
@@ -265,16 +265,16 @@ static NSString * const StubValueKey = @"StubValueKey";
 #pragma mark Invocation Capturing Methods
 
 - (NSDictionary *)userInfoForReceiveMatcherWithCountType:(KWCountType)aCountType count:(NSUInteger)aCount {
-    return [NSDictionary dictionaryWithObjectsAndKeys:self, MatchVerifierKey,
-                                                      [NSNumber numberWithUnsignedInteger:aCountType], CountTypeKey,
-                                                      [NSNumber numberWithUnsignedInteger:aCount], CountKey, nil];
+    return @{MatchVerifierKey: self,
+                                                      CountTypeKey: @(aCountType),
+                                                      CountKey: @(aCount)};
 }
 
 - (NSDictionary *)userInfoForReceiveMatcherWithCountType:(KWCountType)aCountType count:(NSUInteger)aCount value:(id)aValue {
-    return [NSDictionary dictionaryWithObjectsAndKeys:self, MatchVerifierKey,
-                                                      [NSNumber numberWithUnsignedInteger:aCountType], CountTypeKey,
-                                                      [NSNumber numberWithUnsignedInteger:aCount], CountKey,
-                                                      [NSValue valueWithNonretainedObject:aValue], StubValueKey, nil];
+    return @{MatchVerifierKey: self,
+                                                      CountTypeKey: @(aCountType),
+                                                      CountKey: @(aCount),
+                                                      StubValueKey: [NSValue valueWithNonretainedObject:aValue]};
 }
 
 - (id)receive {

--- a/Classes/KWRespondToSelectorMatcher.m
+++ b/Classes/KWRespondToSelectorMatcher.m
@@ -27,7 +27,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return [NSArray arrayWithObject:@"respondToSelector:"];
+    return @[@"respondToSelector:"];
 }
 
 #pragma mark -

--- a/Classes/NSInvocation+OCMAdditions.m
+++ b/Classes/NSInvocation+OCMAdditions.m
@@ -39,79 +39,79 @@
 		{
 			int value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithInt:value];
+			return @(value);
 		}	
 		case 's':
 		{
 			short value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithShort:value];
+			return @(value);
 		}	
 		case 'l':
 		{
 			long value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithLong:value];
+			return @(value);
 		}	
 		case 'q':
 		{
 			long long value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithLongLong:value];
+			return @(value);
 		}	
 		case 'c':
 		{
 			char value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithChar:value];
+			return @(value);
 		}	
 		case 'C':
 		{
 			unsigned char value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithUnsignedChar:value];
+			return @(value);
 		}	
 		case 'I':
 		{
 			unsigned int value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithUnsignedInt:value];
+			return @(value);
 		}	
 		case 'S':
 		{
 			unsigned short value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithUnsignedShort:value];
+			return @(value);
 		}	
 		case 'L':
 		{
 			unsigned long value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithUnsignedLong:value];
+			return @(value);
 		}	
 		case 'Q':
 		{
 			unsigned long long value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithUnsignedLongLong:value];
+			return @(value);
 		}	
 		case 'f':
 		{
 			float value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithFloat:value];
+			return @(value);
 		}	
 		case 'd':
 		{
 			double value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithDouble:value];
+			return @(value);
 		}	
 		case 'B':
 		{
 			bool value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSNumber numberWithBool:value];
+			return @(value);
 		}
 		case '^':
         {
@@ -145,7 +145,7 @@
 	unsigned int i;
 	for(i = 2; i < numberOfArgs; i++)
 	{
-		[description appendFormat:@"%@%@:", (i > 2 ? @" " : @""), [selectorParts objectAtIndex:(i - 2)]];
+		[description appendFormat:@"%@%@:", (i > 2 ? @" " : @""), selectorParts[(i - 2)]];
 		[description appendString:[self argumentDescriptionAtIndex:i]];
 	}
 	

--- a/Classes/NSNumber+KiwiAdditions.m
+++ b/Classes/NSNumber+KiwiAdditions.m
@@ -49,63 +49,63 @@
 }
 
 + (id)numberWithBoolBytes:(const void *)bytes {
-    return [NSNumber numberWithBool:*(const BOOL *)bytes];
+    return @(*(const BOOL *)bytes);
 }
 
 + (id)numberWithCharBytes:(const void *)bytes {
-    return [NSNumber numberWithChar:*(const char *)bytes];
+    return @(*(const char *)bytes);
 }
 
 + (id)numberWithDoubleBytes:(const void *)bytes {
-    return [NSNumber numberWithDouble:*(const double *)bytes];
+    return @(*(const double *)bytes);
 }
 
 + (id)numberWithFloatBytes:(const void *)bytes {
-    return [NSNumber numberWithFloat:*(const float *)bytes];
+    return @(*(const float *)bytes);
 }
 
 + (id)numberWithIntBytes:(const void *)bytes {
-    return [NSNumber numberWithInt:*(const int *)bytes];
+    return @(*(const int *)bytes);
 }
 
 + (id)numberWithIntegerBytes:(const void *)bytes {
-    return [NSNumber numberWithInteger:*(const NSInteger *)bytes];
+    return @(*(const NSInteger *)bytes);
 }
 
 + (id)numberWithLongBytes:(const void *)bytes {
-    return [NSNumber numberWithLong:*(const long *)bytes];
+    return @(*(const long *)bytes);
 }
 
 + (id)numberWithLongLongBytes:(const void *)bytes {
-    return [NSNumber numberWithLongLong:*(const long long *)bytes];
+    return @(*(const long long *)bytes);
 }
 
 + (id)numberWithShortBytes:(const void *)bytes {
-    return [NSNumber numberWithShort:*(const short *)bytes];
+    return @(*(const short *)bytes);
 }
 
 + (id)numberWithUnsignedCharBytes:(const void *)bytes {
-    return [NSNumber numberWithChar:*(const unsigned char *)bytes];
+    return @(*(const unsigned char *)bytes);
 }
 
 + (id)numberWithUnsignedIntBytes:(const void *)bytes {
-    return [NSNumber numberWithInt:*(const unsigned int *)bytes];
+    return @(*(const unsigned int *)bytes);
 }
 
 + (id)numberWithUnsignedIntegerBytes:(const void *)bytes {
-    return [NSNumber numberWithInteger:*(const NSUInteger *)bytes];
+    return @(*(const NSUInteger *)bytes);
 }
 
 + (id)numberWithUnsignedLongBytes:(const void *)bytes {
-    return [NSNumber numberWithLong:*(const unsigned long *)bytes];
+    return @(*(const unsigned long *)bytes);
 }
 
 + (id)numberWithUnsignedLongLongBytes:(const void *)bytes {
-    return [NSNumber numberWithLongLong:*(const unsigned long long *)bytes];
+    return @(*(const unsigned long long *)bytes);
 }
 
 + (id)numberWithUnsignedShortBytes:(const void *)bytes {
-    return [NSNumber numberWithShort:*(const unsigned short *)bytes];
+    return @(*(const unsigned short *)bytes);
 }
 
 @end

--- a/Classes/NSObject+KiwiStubAdditions.m
+++ b/Classes/NSObject+KiwiStubAdditions.m
@@ -33,12 +33,12 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 
 - (void)invocationCapturer:(KWInvocationCapturer *)anInvocationCapturer didCaptureInvocation:(NSInvocation *)anInvocation {
     KWMessagePattern *messagePattern = [KWMessagePattern messagePatternFromInvocation:anInvocation];
-    id value = [anInvocationCapturer.userInfo objectForKey:StubValueKey];
-    if (![anInvocationCapturer.userInfo objectForKey:StubSecondValueKey]) {
+    id value = (anInvocationCapturer.userInfo)[StubValueKey];
+    if (!(anInvocationCapturer.userInfo)[StubSecondValueKey]) {
         [self stubMessagePattern:messagePattern andReturn:value];
     } else {
-        id times = [anInvocationCapturer.userInfo objectForKey:ChangeStubValueAfterTimesKey];
-        id secondValue = [anInvocationCapturer.userInfo objectForKey:StubSecondValueKey];
+        id times = (anInvocationCapturer.userInfo)[ChangeStubValueAfterTimesKey];
+        id secondValue = (anInvocationCapturer.userInfo)[StubSecondValueKey];
         [self stubMessagePattern:messagePattern andReturn:value times:times afterThatReturn:secondValue];
     }
 }
@@ -75,12 +75,12 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 }
 
 - (id)stubAndReturn:(id)aValue {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:aValue forKey:StubValueKey];
+    NSDictionary *userInfo = @{StubValueKey: aValue};
     return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
 }
 
 - (id)stubAndReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue {
-    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys: aValue, StubValueKey, times, ChangeStubValueAfterTimesKey, aSecondValue, StubSecondValueKey, nil];
+    NSDictionary *userInfo = @{StubValueKey: aValue, ChangeStubValueAfterTimesKey: times, StubSecondValueKey: aSecondValue};
     return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
 }
 

--- a/Tests/KWBeBetweenMatcherTest.m
+++ b/Tests/KWBeBetweenMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeBetweenMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"beBetween:and:", @"beInTheIntervalFrom:to:", nil];
+    NSArray *expectedStrings = @[@"beBetween:and:", @"beInTheIntervalFrom:to:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWBeEmptyMatcherTest.m
+++ b/Tests/KWBeEmptyMatcherTest.m
@@ -18,21 +18,21 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeEmptyMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObject:@"beEmpty"];
+    NSArray *expectedStrings = @[@"beEmpty"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
 }
 
 - (void)testItShouldMatchEmptyCollections {
-    id subject = [NSDictionary dictionary];
+    id subject = @{};
     id matcher = [KWBeEmptyMatcher matcherWithSubject:subject];
     [matcher beEmpty];
     STAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldNotMatchNonEmptyCollections {
-    id subject = [NSDictionary dictionaryWithObject:@"bar" forKey:@"foo"];
+    id subject = @{@"foo": @"bar"};
     id matcher = [KWBeEmptyMatcher matcherWithSubject:subject];
     [matcher beEmpty];
     STAssertFalse([matcher evaluate], @"expected negative match");

--- a/Tests/KWBeIndenticalToMatcherTest.m
+++ b/Tests/KWBeIndenticalToMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeIdenticalToMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"beIdenticalTo:", nil];
+    NSArray *expectedStrings = @[@"beIdenticalTo:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWBeKindOfClassMatcherTest.m
+++ b/Tests/KWBeKindOfClassMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeKindOfClassMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObject:@"beKindOfClass:"];
+    NSArray *expectedStrings = @[@"beKindOfClass:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWBeMemberOfClassMatcherTest.m
+++ b/Tests/KWBeMemberOfClassMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeMemberOfClassMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObject:@"beMemberOfClass:"];
+    NSArray *expectedStrings = @[@"beMemberOfClass:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWBeTrueMatcherTest.m
+++ b/Tests/KWBeTrueMatcherTest.m
@@ -18,14 +18,14 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeTrueMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"beTrue", @"beFalse", @"beYes", @"beNo", nil];
+    NSArray *expectedStrings = @[@"beTrue", @"beFalse", @"beYes", @"beNo"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
 }
 
 - (void)testItShouldRaiseWhenTheSubjectIsInvalid {
-    id subject = [NSArray array];
+    id subject = @[];
     id matcher = [KWBeTrueMatcher matcherWithSubject:subject];
     [matcher beTrue];
     STAssertThrowsSpecificNamed([matcher evaluate], NSException, @"KWMatcherException", @"expected raised exception");

--- a/Tests/KWBeWithinMatcherTest.m
+++ b/Tests/KWBeWithinMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeWithinMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"beWithin:of:", @"equal:withDelta:", nil];
+    NSArray *expectedStrings = @[@"beWithin:of:", @"equal:withDelta:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWBlockRaiseMatcherTest.m
+++ b/Tests/KWBlockRaiseMatcherTest.m
@@ -18,10 +18,10 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBlockRaiseMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"raise",
+    NSArray *expectedStrings = @[@"raise",
                                                          @"raiseWithName:",
                                                          @"raiseWithReason:",
-                                                         @"raiseWithName:reason:", nil];
+                                                         @"raiseWithName:reason:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWChangeMatcherTest.m
+++ b/Tests/KWChangeMatcherTest.m
@@ -20,7 +20,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWChangeMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"change:", @"change:by:", nil];
+    NSArray *expectedStrings = @[@"change:", @"change:by:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWConformToProtocolMatcherTest.m
+++ b/Tests/KWConformToProtocolMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWConformToProtocolMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObject:@"conformToProtocol:"];
+    NSArray *expectedStrings = @[@"conformToProtocol:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWContainMatcherTest.m
+++ b/Tests/KWContainMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWContainMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"contain:", @"containObjectsInArray:", nil];
+    NSArray *expectedStrings = @[@"contain:", @"containObjectsInArray:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
@@ -32,30 +32,30 @@
 }
 
 - (void)testItShouldMatchContainedElements {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWContainMatcher matcherWithSubject:subject];
     [matcher contain:@"liger"];
     STAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testitShouldNotMatchNonContainedElements {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWContainMatcher matcherWithSubject:subject];
     [matcher contain:@"lion"];
     STAssertFalse([matcher evaluate], @"expected negative match");
 }
 
 - (void)testItShouldMatchContainedArrayObjects {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
-    id objects = [NSArray arrayWithObjects:@"cat", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
+    id objects = @[@"cat", @"liger"];
     id matcher = [KWContainMatcher matcherWithSubject:subject];
     [matcher containObjectsInArray:objects];
     STAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldNotMatchNonContainedArrayObjects {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
-    id objects = [NSArray arrayWithObjects:@"cat", @"lion", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
+    id objects = @[@"cat", @"lion"];
     id matcher = [KWContainMatcher matcherWithSubject:subject];
     [matcher containObjectsInArray:objects];
     STAssertFalse([matcher evaluate], @"expected negative match");
@@ -63,7 +63,7 @@
 
 - (void)testItShouldMatchContainedElementsWithGenericMatcher
 {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWContainMatcher matcherWithSubject:subject];
     [matcher contain:hasPrefix(@"li")];
     STAssertTrue([matcher evaluate], @"expected positive match");
@@ -71,7 +71,7 @@
 
 - (void)testItShouldNotMatchContainedElementsWithGenericMatcher
 {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWContainMatcher matcherWithSubject:subject];
     [matcher contain:hasPrefix(@"ele")];
     STAssertFalse([matcher evaluate], @"expected negative match");
@@ -84,7 +84,7 @@
     [matcher contain:@"liger"];
     STAssertEqualObjects(@"contain \"liger\"", [matcher description], @"description should match");
 
-    [matcher containObjectsInArray:[NSArray arrayWithObjects:@"cat", @"lion", nil]];
+    [matcher containObjectsInArray:@[@"cat", @"lion"]];
     STAssertEqualObjects(@"contain all of (\"cat\", \"lion\")", [matcher description], @"description should match");
 
     [matcher contain:hasPrefix(@"ele")];

--- a/Tests/KWEqualMatcherTest.m
+++ b/Tests/KWEqualMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWEqualMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"equal:", nil];
+    NSArray *expectedStrings = @[@"equal:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
@@ -47,14 +47,14 @@
 }
 
 - (void)testItShouldMatchNumberBoxedValuesWithKiwiBoxedValues {
-  id matcher = [KWEqualMatcher matcherWithSubject:[NSNumber numberWithInteger:123]];
+  id matcher = [KWEqualMatcher matcherWithSubject:@123];
   [matcher equal:theValue(123)];
   STAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldMatchKiwiBoxedValuesWithNumberBoxedValues {
   id matcher = [KWEqualMatcher matcherWithSubject:theValue(123)];
-  [matcher equal:[NSNumber numberWithInteger:123]];
+  [matcher equal:@123];
   STAssertTrue([matcher evaluate], @"expected positive match");
 }
 

--- a/Tests/KWHaveMatcherTest.m
+++ b/Tests/KWHaveMatcherTest.m
@@ -19,40 +19,40 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWHaveMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"haveCountOf:",
+    NSArray *expectedStrings = @[@"haveCountOf:",
                                                          @"haveCountOfAtLeast:",
                                                          @"haveCountOfAtMost:",
                                                          @"have:itemsForInvocation:",
                                                          @"haveAtLeast:itemsForInvocation:",
-                                                         @"haveAtMost:itemsForInvocation:", nil];
+                                                         @"haveAtMost:itemsForInvocation:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
 }
 
 - (void)testItShouldMatchExactCounts {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher haveCountOf:4];
     STAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldNotMatchNonExactCounts {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher haveCountOf:3];
     STAssertFalse([matcher evaluate], @"expected negative match");
 }
 
 - (void)testItShouldMatchAtLeastCounts {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher haveCountOfAtLeast:3];
     STAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldMatchAtMostCounts {
-    id subject = [NSArray arrayWithObjects:@"dog", @"cat", @"tiger", @"liger", nil];
+    id subject = @[@"dog", @"cat", @"tiger", @"liger"];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher haveCountOfAtMost:5];
     STAssertTrue([matcher evaluate], @"expected positive match");
@@ -60,9 +60,9 @@
 
 - (void)testItShouldMatchExactCountsForInvocation {
     id subject = [Cruiser cruiser];
-    [subject setFighters:[NSArray arrayWithObjects:[Fighter fighterWithCallsign:@"Viper 1"],
+    [subject setFighters:@[[Fighter fighterWithCallsign:@"Viper 1"],
                                                    [Fighter fighterWithCallsign:@"Viper 2"],
-                                                   [Fighter fighterWithCallsign:@"Viper 3"], nil]];
+                                                   [Fighter fighterWithCallsign:@"Viper 3"]]];
     NSInvocation *invocation = [NSInvocation invocationWithTarget:subject selector:@selector(fighters)];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher have:3 itemsForInvocation:invocation];
@@ -71,9 +71,9 @@
 
 - (void)testItShouldMatchAtLeastCountsForInvocation {
     id subject = [Cruiser cruiser];
-    [subject setFighters:[NSArray arrayWithObjects:[Fighter fighterWithCallsign:@"Viper 1"],
+    [subject setFighters:@[[Fighter fighterWithCallsign:@"Viper 1"],
                                                    [Fighter fighterWithCallsign:@"Viper 2"],
-                                                   [Fighter fighterWithCallsign:@"Viper 3"], nil]];
+                                                   [Fighter fighterWithCallsign:@"Viper 3"]]];
     NSInvocation *invocation = [NSInvocation invocationWithTarget:subject selector:@selector(fighters)];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher haveAtLeast:2 itemsForInvocation:invocation];
@@ -82,9 +82,9 @@
 
 - (void)testItShouldMatchAtMostCountsForInvocation {
     id subject = [Cruiser cruiser];
-    [subject setFighters:[NSArray arrayWithObjects:[Fighter fighterWithCallsign:@"Viper 1"],
+    [subject setFighters:@[[Fighter fighterWithCallsign:@"Viper 1"],
                                                    [Fighter fighterWithCallsign:@"Viper 2"],
-                                                   [Fighter fighterWithCallsign:@"Viper 3"], nil]];
+                                                   [Fighter fighterWithCallsign:@"Viper 3"]]];
     NSInvocation *invocation = [NSInvocation invocationWithTarget:subject selector:@selector(fighters)];
     id matcher = [KWHaveMatcher matcherWithSubject:subject];
     [matcher haveAtMost:4 itemsForInvocation:invocation];
@@ -125,9 +125,9 @@
     // invocation matchers
 
     id subject = [Cruiser cruiser];
-    [subject setFighters:[NSArray arrayWithObjects:[Fighter fighterWithCallsign:@"Viper 1"],
+    [subject setFighters:@[[Fighter fighterWithCallsign:@"Viper 1"],
                           [Fighter fighterWithCallsign:@"Viper 2"],
-                          [Fighter fighterWithCallsign:@"Viper 3"], nil]];
+                          [Fighter fighterWithCallsign:@"Viper 3"]]];
     NSInvocation *invocation = [NSInvocation invocationWithTarget:subject selector:@selector(fighters)];
 
     [matcher have:3 itemsForInvocation:invocation];

--- a/Tests/KWInequalityMatcherTest.m
+++ b/Tests/KWInequalityMatcherTest.m
@@ -18,10 +18,10 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWInequalityMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"beLessThan:",
+    NSArray *expectedStrings = @[@"beLessThan:",
                                                          @"beLessThanOrEqualTo:",
                                                          @"beGreaterThan:",
-                                                         @"beGreaterThanOrEqualTo:", nil];
+                                                         @"beGreaterThanOrEqualTo:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWMessagePatternTest.m
+++ b/Tests/KWMessagePatternTest.m
@@ -26,9 +26,9 @@
     KWMessagePattern *messagePattern = [self messagePatternWithSelector:@selector(dictionaryWithObjects:forKeys:count:) arguments:@"foo",
                                                                                                                                   nil,
                                                                                                                                   [KWValue valueWithUnsignedInt:1]];
-    STAssertEqualObjects([messagePattern.argumentFilters objectAtIndex:0], @"foo", @"expected matching argument");
-    STAssertEqualObjects([messagePattern.argumentFilters objectAtIndex:1], [KWNull null], @"expected matching argument");
-    STAssertEqualObjects([messagePattern.argumentFilters objectAtIndex:2], [KWValue valueWithUnsignedInt:1], @"expected matching argument");
+    STAssertEqualObjects((messagePattern.argumentFilters)[0], @"foo", @"expected matching argument");
+    STAssertEqualObjects((messagePattern.argumentFilters)[1], [KWNull null], @"expected matching argument");
+    STAssertEqualObjects((messagePattern.argumentFilters)[2], [KWValue valueWithUnsignedInt:1], @"expected matching argument");
 }
 
 - (void)testItShouldMatchInvocationsWithNilArguments {
@@ -97,7 +97,7 @@
 
 - (void)testItShouldCompareMessagePatternsWithNilAndNonNilArgumentFilters {
     KWMessagePattern *messagePattern1 = [KWMessagePattern messagePatternWithSelector:@selector(foobar:)];
-    NSArray *argumentFilters = [NSArray arrayWithObject:[KWValue valueWithUnsignedInt:42]];
+    NSArray *argumentFilters = @[[KWValue valueWithUnsignedInt:42]];
     KWMessagePattern *messagePattern2 = [KWMessagePattern messagePatternWithSelector:@selector(foobar:) argumentFilters:argumentFilters];
     STAssertFalse([messagePattern1 isEqual:messagePattern2], @"expected message patterns to compare as not equal");
     STAssertFalse([messagePattern2 isEqual:messagePattern1], @"expected message patterns to compare as not equal");

--- a/Tests/KWMockTest.m
+++ b/Tests/KWMockTest.m
@@ -148,7 +148,7 @@
     TestSpy *spy1 = [TestSpy testSpy];
     TestSpy *spy2 = [TestSpy testSpy];
     KWMessagePattern *messagePattern1 = [KWMessagePattern messagePatternWithSelector:@selector(energyLevelInWarpCore:)];
-    NSArray *argumentFilters = [NSArray arrayWithObject:[KWValue valueWithUnsignedInt:2]];
+    NSArray *argumentFilters = @[[KWValue valueWithUnsignedInt:2]];
     KWMessagePattern *messagePattern2 = [KWMessagePattern messagePatternWithSelector:@selector(energyLevelInWarpCore:) argumentFilters:argumentFilters];
 
     [mock addMessageSpy:spy1 forMessagePattern:messagePattern1];
@@ -325,8 +325,8 @@
     id mock = [Cruiser mock];
     __block BOOL called = NO;
     [mock stub:@selector(setValue:forKey:) withBlock:^id(NSArray *params) {
-        STAssertEquals([params objectAtIndex:0], @"baz", @"expected arg 1 of setValue:forKey: to be 'baz'");
-        STAssertEquals([params objectAtIndex:1], @"foo", @"expected arg 2 of setValue:forKey: to be 'foo'");
+        STAssertEquals(params[0], @"baz", @"expected arg 1 of setValue:forKey: to be 'baz'");
+        STAssertEquals(params[1], @"foo", @"expected arg 2 of setValue:forKey: to be 'foo'");
         called = YES;
         return nil;
     }];
@@ -338,8 +338,8 @@
     id mock = [Cruiser mock];
     __block BOOL called = NO;
     [mock stub:@selector(setValue:forKeyPath:) withBlock:^id(NSArray *params) {
-        STAssertEquals([params objectAtIndex:0], @"baz", @"expected arg 1 of setValue:forKeyPath: to be 'baz'");
-        STAssertEquals([params objectAtIndex:1], @"foo.bar", @"expected arg 2 of setValue:forKey: to be 'foo.bar'");
+        STAssertEquals(params[0], @"baz", @"expected arg 1 of setValue:forKeyPath: to be 'baz'");
+        STAssertEquals(params[1], @"foo.bar", @"expected arg 2 of setValue:forKey: to be 'foo.bar'");
         called = YES;
         return nil;
     }];

--- a/Tests/KWRaiseMatcherTest.m
+++ b/Tests/KWRaiseMatcherTest.m
@@ -18,10 +18,10 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWRaiseMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObjects:@"raiseWhenSent:",
+    NSArray *expectedStrings = @[@"raiseWhenSent:",
                                                          @"raiseWithName:whenSent:",
                                                          @"raiseWithReason:whenSent:",
-                                                         @"raiseWithName:reason:whenSent:", nil];
+                                                         @"raiseWithName:reason:whenSent:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWRealObjectSpyTest.m
+++ b/Tests/KWRealObjectSpyTest.m
@@ -44,7 +44,7 @@
     TestSpy *spy1 = [TestSpy testSpy];
     TestSpy *spy2 = [TestSpy testSpy];
     KWMessagePattern *messagePattern1 = [KWMessagePattern messagePatternWithSelector:@selector(energyLevelInWarpCore:)];
-    NSArray *argumentFilters = [NSArray arrayWithObject:[KWValue valueWithUnsignedInt:2]];
+    NSArray *argumentFilters = @[[KWValue valueWithUnsignedInt:2]];
     KWMessagePattern *messagePattern2 = [KWMessagePattern messagePatternWithSelector:@selector(energyLevelInWarpCore:) argumentFilters:argumentFilters];
 
     [cruiser addMessageSpy:spy1 forMessagePattern:messagePattern1];

--- a/Tests/KWReceiveMatcherTest.m
+++ b/Tests/KWReceiveMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     id matcherStrings = [KWReceiveMatcher matcherStrings];
-    id expectedStrings = [NSArray arrayWithObjects:@"receive:",
+    id expectedStrings = @[@"receive:",
                                                    @"receive:withCount:",
                                                    @"receive:withCountAtLeast:",
                                                    @"receive:withCountAtMost:",
@@ -27,7 +27,7 @@
                                                    @"receive:andReturn:withCountAtLeast:",
                                                    @"receive:andReturn:withCountAtMost:",
                                                    @"receiveMessagePattern:countType:count:",
-                                                   @"receiveMessagePattern:andReturn:countType:count:", nil];
+                                                   @"receiveMessagePattern:andReturn:countType:count:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWRespondToSelectorMatcherTest.m
+++ b/Tests/KWRespondToSelectorMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWRespondToSelectorMatcher matcherStrings];
-    NSArray *expectedStrings = [NSArray arrayWithObject:@"respondToSelector:"];
+    NSArray *expectedStrings = @[@"respondToSelector:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");

--- a/Tests/KWStringContainsMatcherTest.m
+++ b/Tests/KWStringContainsMatcherTest.m
@@ -26,7 +26,7 @@
 
 - (void)testShouldNotMatchItemIfItIsNotAString
 {
-  STAssertFalse([hasSubstring(@"sub") matches:[NSArray array]], @"Should match string with array");
+  STAssertFalse([hasSubstring(@"sub") matches:@[]], @"Should match string with array");
 }
 
 @end

--- a/Tests/KWStubTest.m
+++ b/Tests/KWStubTest.m
@@ -32,7 +32,7 @@
 
 - (void)testItShouldNotProcessNonMatchedInvocations {
     id subject = [Cruiser cruiser];
-    id argumentFilters = [NSArray arrayWithObject:[KWValue valueWithUnsignedInt:15]];
+    id argumentFilters = @[[KWValue valueWithUnsignedInt:15]];
     KWMessagePattern *messagePattern = [KWMessagePattern messagePatternWithSelector:@selector(energyLevelInWarpCore:) argumentFilters:argumentFilters];
     id stub = [KWStub stubWithMessagePattern:messagePattern value:[KWValue valueWithFloat:13.0f]];
     NSUInteger index = 17;

--- a/Tests/Test Classes/TestReporter.m
+++ b/Tests/Test Classes/TestReporter.m
@@ -67,7 +67,7 @@
 }
 
 - (KWFailure *)onlyFailure {
-    return [self.failures objectAtIndex:0];
+    return (self.failures)[0];
 }
 
 @end


### PR DESCRIPTION
Objective-C literals have been out for a while and iOS community generally agrees that they account for a better, more readable code ([reference](http://nsscreencast.com/episodes/27-new-objective-c-syntax)).

This PR has been simply created by using Xcode's `Edit -> Refactor -> Convert To Modern Objective-C Syntax` feature (and couple of manual edits, see below).

Xcode gave me some warnings in `NSNumber (KiwiAdditions)` category, I had to convert couple of methods manually there). Would be great if someone with more low-level C experience could take a look and see if I didn't screw anything up.
