### PR TITLE
Add stub:withBlock: to NSObject stub category

### DIFF
--- a/Classes/NSObject+KiwiStubAdditions.h
+++ b/Classes/NSObject+KiwiStubAdditions.h
@@ -16,6 +16,7 @@
 #pragma mark Stubbing Methods
 
 - (void)stub:(SEL)aSelector;
+- (void)stub:(SEL)aSelector withBlock:(id (^)(NSArray *params))block;
 - (void)stub:(SEL)aSelector withArguments:(id)firstArgument, ...;
 - (void)stub:(SEL)aSelector andReturn:(id)aValue;
 - (void)stub:(SEL)aSelector andReturn:(id)aValue withArguments:(id)firstArgument, ...;

--- a/Classes/NSObject+KiwiStubAdditions.m
+++ b/Classes/NSObject+KiwiStubAdditions.m
@@ -51,6 +51,11 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     [self stubMessagePattern:messagePattern andReturn:nil];
 }
 
+- (void)stub:(SEL)aSelector withBlock:(id (^)(NSArray *))block {
+    KWMessagePattern *messagePattern = [KWMessagePattern messagePatternWithSelector:aSelector];
+    [self stubMessagePattern:messagePattern withBlock:block];
+}
+
 - (void)stub:(SEL)aSelector withArguments:(id)firstArgument, ... {
     va_list argumentList;
     va_start(argumentList, firstArgument);
@@ -93,6 +98,18 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     Class interceptClass = KWSetupObjectInterceptSupport(self);
     KWSetupMethodInterceptSupport(interceptClass, aMessagePattern.selector);
     KWStub *stub = [KWStub stubWithMessagePattern:aMessagePattern value:aValue];
+    KWAssociateObjectStub(self, stub);
+}
+
+- (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern withBlock:(id (^)(NSArray *params))block {
+    if ([self methodSignatureForSelector:aMessagePattern.selector] == nil) {
+        [NSException raise:@"KWStubException" format:@"cannot stub -%@ because no such method exists",
+         NSStringFromSelector(aMessagePattern.selector)];
+    }
+    
+    Class interceptClass = KWSetupObjectInterceptSupport(self);
+    KWSetupMethodInterceptSupport(interceptClass, aMessagePattern.selector);
+    KWStub *stub = [KWStub stubWithMessagePattern:aMessagePattern block:block];
     KWAssociateObjectStub(self, stub);
 }
 

--- a/Tests/KWRealObjectStubTest.m
+++ b/Tests/KWRealObjectStubTest.m
@@ -168,6 +168,14 @@
     STAssertThrows([cruiser captureArgument:@selector(foo) atIndex:0], @"expected to throw exception");
 }
 
+- (void)testItShouldStubWithBlock {
+    Cruiser *cruiser = [Cruiser cruiser];
+    [cruiser stub:@selector(classification) withBlock:^id(NSArray *params) {
+        return @"Enterprise";
+    }];
+    STAssertEquals([cruiser classification], @"Enterprise", @"expected method to be stubbed with block");
+}
+
 @end
 
 #endif // #if KW_TESTS_ENABLED


### PR DESCRIPTION
Methods on real objects can now be stubbed with a block
