### PR TITLE
Rephrase name property on kwmock

### DIFF
--- a/Classes/KWMock.h
+++ b/Classes/KWMock.h
@@ -16,7 +16,7 @@
 @interface KWMock : NSObject {
 @private
     BOOL isNullMock;
-    NSString *name;
+    NSString *mockName;
     Class mockedClass;
     Protocol *mockedProtocol;
     NSMutableArray *stubs;
@@ -51,7 +51,7 @@
 #pragma mark Properties
 
 @property (nonatomic, readonly) BOOL isNullMock;
-@property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly) NSString *mockName;
 @property (nonatomic, readonly) Class mockedClass;
 @property (nonatomic, readonly) Protocol *mockedProtocol;
 

--- a/Classes/KWMock.m
+++ b/Classes/KWMock.m
@@ -103,7 +103,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 - (id)initAsNullMock:(BOOL)nullMockFlag withName:(NSString *)aName forClass:(Class)aClass protocol:(Protocol *)aProtocol {
     if ((self = [super init])) {
         isNullMock = nullMockFlag;
-        name = [aName copy];
+        mockName = [aName copy];
         mockedClass = aClass;
         mockedProtocol = aProtocol;
         stubs = [[NSMutableArray alloc] init];
@@ -147,7 +147,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 }
 
 - (void)dealloc {
-    [name release];
+    [mockName release];
     [stubs release];
     [expectedMessagePatterns release];
     [messageSpies release];
@@ -158,7 +158,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 #pragma mark Properties
 
 @synthesize isNullMock;
-@synthesize name;
+@synthesize mockName;
 @synthesize mockedClass;
 @synthesize mockedProtocol;
 @synthesize stubs;
@@ -365,10 +365,10 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 #pragma mark Handling Invocations
 
 - (NSString *)namePhrase {
-    if (self.name == nil)
+    if (self.mockName == nil)
         return @"mock";
     else
-        return [NSString stringWithFormat:@"mock \"%@\"", self.name];
+        return [NSString stringWithFormat:@"mock \"%@\"", self.mockName];
 }
 
 - (BOOL)processReceivedInvocation:(NSInvocation *)invocation {

--- a/Tests/KWMockTest.m
+++ b/Tests/KWMockTest.m
@@ -29,7 +29,7 @@
     STAssertNotNil(mock, @"expected a mock object to be initialized");
     STAssertEqualObjects([mock mockedClass], mockedClass, @"expected the mockedClass property to be set");
     STAssertTrue([mock isNullMock], @"expected the isNullObject property to be set");
-    STAssertEqualObjects([mock name], @"Car mock", @"expected class mock to have the correct name");
+    STAssertEqualObjects([mock mockName], @"Car mock", @"expected class mock to have the correct mockName");
 }
 
 - (void)testItShouldInitializeForAProtocolWithANameAsANullObject {
@@ -39,7 +39,7 @@
     STAssertNotNil(mock, @"expected a mock object to be initialized");
     STAssertEqualObjects([mock mockedProtocol], mockedProtocol, @"expected the mockedProtocol property to be set");
     STAssertTrue([mock isNullMock], @"expected the isNullObject property to be set");
-    STAssertEqualObjects([mock name], @"JumpCapable mock", @"expected class mock to have the correct name");
+    STAssertEqualObjects([mock mockName], @"JumpCapable mock", @"expected class mock to have the correct mockName");
 }
 
 //- (void)testItShouldRaiseWhenReceivingUnexpectedMessageAsAMock {
@@ -60,8 +60,8 @@
 
 - (void)testItShouldStubTheNameMethodOnAClassMock {
     id mock = [Galaxy mock];
-    [[mock stubAndReturn:@"fake galaxy name"] name];
-    STAssertEqualObjects([mock name], @"fake galaxy name", @"expected name property to return the stub value");
+    [[mock stubAndReturn:@"fake galaxy mockName"] name];
+    STAssertEqualObjects([mock name], @"fake galaxy mockName", @"expected mockName property to return the stub value");
 }
 
 - (void)testItShouldBeOkToStubOnSingletons {


### PR DESCRIPTION
Twice in the last few days I've hit the issue that you cannot mock or stub a property called "name" using Kiwi. I gather this is because KWMock has its own first class property called "name".

Since Kiwi is a generic library, and "name" is a common property to have on the objects being stubbed, I changed the underlying property on KWMock to mockName. This is following the convention of other properties on KWMock like mockedClass and mockedProtocol.

I added a unit test on KWMock exposing the inability to mock the "name" property (as it was returning the actual KWMock name property. Renaming "name" to "mockName" passes those tests.
