### PR TITLE
Fix the hiding of true failure reason if no callSite is set on KWFailure

### DIFF
--- a/Classes/KWFailure.m
+++ b/Classes/KWFailure.m
@@ -56,9 +56,12 @@
 #pragma mark Getting Exception Representations
 
 - (NSException *)exceptionValue {
-    NSNumber *lineNumber = @(self.callSite.lineNumber);
-    NSDictionary *userInfo = @{SenTestFilenameKey: self.callSite.filename,
-                                                                        SenTestLineNumberKey: lineNumber};
+    NSDictionary *userInfo = nil;
+    if (self.callSite) {
+        NSNumber *lineNumber = @(self.callSite.lineNumber);
+        userInfo = @{SenTestFilenameKey: self.callSite.filename,
+                                                                            SenTestLineNumberKey: lineNumber};
+    }
     return [NSException exceptionWithName:@"KWFailureException" reason:message userInfo:userInfo];
 }
 

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		44FC0EC016B6377D0050D616 /* NSObject+KiwiStubAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982CDA16A802920030A0B1 /* NSObject+KiwiStubAdditions.h */; };
 		44FC0EC116B6377D0050D616 /* NSObject+KiwiVerifierAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982CDC16A802920030A0B1 /* NSObject+KiwiVerifierAdditions.h */; };
 		44FC0EC216B6377D0050D616 /* NSValue+KiwiAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F982CDE16A802920030A0B1 /* NSValue+KiwiAdditions.h */; };
+		492F3A7A16D5F7DC008E3C49 /* KWFailureTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 492F3A7916D5F7DC008E3C49 /* KWFailureTest.m */; };
 		4BA52D0115487F0C00FC957B /* KWCaptureTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BA52D0015487F0C00FC957B /* KWCaptureTest.m */; };
 		511901A516A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
 		511901A616A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
@@ -628,6 +629,7 @@
 		28AD733E0D9D9553002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindow.xib; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* Kiwi_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Kiwi_Prefix.pch; sourceTree = "<group>"; };
+		492F3A7916D5F7DC008E3C49 /* KWFailureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWFailureTest.m; sourceTree = "<group>"; };
 		4BA52D0015487F0C00FC957B /* KWCaptureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWCaptureTest.m; sourceTree = "<group>"; };
 		511901A016A95803006E7359 /* KWChangeMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWChangeMatcherTest.m; sourceTree = "<group>"; };
 		511901A316A95CDE006E7359 /* KWChangeMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KWChangeMatcher.h; path = Classes/KWChangeMatcher.h; sourceTree = "<group>"; };
@@ -1248,6 +1250,7 @@
 			isa = PBXGroup;
 			children = (
 				F5DBB72E116CBC4A00583385 /* KWTestCaseTest.m */,
+				492F3A7916D5F7DC008E3C49 /* KWFailureTest.m */,
 			);
 			name = Specs;
 			sourceTree = "<group>";
@@ -1897,6 +1900,7 @@
 				9F982A4316A801800030A0B1 /* TestVerifier.m in Sources */,
 				89F9CB7C16B1C2C400E87D34 /* KWFunctionalTests.m in Sources */,
 				9F820DBC16BB6808003A1BA5 /* KWChangeMatcherTest.m in Sources */,
+				492F3A7A16D5F7DC008E3C49 /* KWFailureTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/KWFailureTest.m
+++ b/Tests/KWFailureTest.m
@@ -1,0 +1,25 @@
+//
+//  KWFailureTest.m
+//  Kiwi
+//
+//  Created by Andrew J Wagner on 2/20/13.
+//  Copyright (c) 2013 Allen Ding. All rights reserved.
+//
+
+#import "KiwiTestConfiguration.h"
+#import "TestClasses.h"
+#import "KWFailure.h"
+
+@interface KWFailureTest : SenTestCase
+
+@end
+
+@implementation KWFailureTest
+
+- (void)testExceptionValue {
+    KWFailure *failure = [KWFailure failureWithCallSite:nil message:@"a message"];
+    STAssertNil([failure exceptionValue].userInfo, @"userInfo should be nil since there was no callSite");
+    STAssertEquals([failure exceptionValue].reason, @"a message", @"the reason of the exception should be the same as the one used to create the failure");
+}
+
+@end


### PR DESCRIPTION
If a KWFailure was initialized without a callSite an exception would be
raised while trying to generate the exceptionValue when trying to insert nil
into the user info dictionary.
