### PR TITLE
Receive matcher now stubs its expected message, as in RSpec.

### DIFF
--- a/Classes/KWIntercept.h
+++ b/Classes/KWIntercept.h
@@ -38,7 +38,7 @@ void KWClearStubsAndSpies(void);
 #pragma mark -
 #pragma mark Managing Objects Stubs
 
-void KWAssociateObjectStub(id anObject, KWStub *aStub);
+void KWAssociateObjectStub(id anObject, KWStub *aStub, BOOL overrideExisting);
 void KWClearObjectStubs(id anObject);
 void KWClearAllObjectStubs(void);
 

--- a/Classes/KWIntercept.m
+++ b/Classes/KWIntercept.m
@@ -150,7 +150,7 @@ void KWSetupMethodInterceptSupport(Class interceptClass, SEL aSelector) {
                                 : class_getInstanceMethod(interceptClass, aSelector);
 
     if (method == nil) {
-        [NSException raise:NSInvalidArgumentException format:@"cannot setup intercept support for -%@ because there is no such method exists",
+        [NSException raise:NSInvalidArgumentException format:@"cannot setup intercept support for -%@ because no such method exists",
                                                              NSStringFromSelector(aSelector)];
     }
 
@@ -235,7 +235,7 @@ void KWClearStubsAndSpies(void) {
 #pragma mark -
 #pragma mark Managing Objects Stubs
 
-void KWAssociateObjectStub(id anObject, KWStub *aStub) {
+void KWAssociateObjectStub(id anObject, KWStub *aStub, BOOL overrideExisting) {
     if (KWObjectStubs == nil)
         KWObjectStubs = [[NSMutableDictionary alloc] init];
 
@@ -254,8 +254,12 @@ void KWAssociateObjectStub(id anObject, KWStub *aStub) {
         KWStub *existingStub = stubs[i];
 
         if ([aStub.messagePattern isEqualToMessagePattern:existingStub.messagePattern]) {
-            [stubs removeObjectAtIndex:i];
-            break;
+            if (overrideExisting) {
+                [stubs removeObjectAtIndex:i];
+                break;
+            } else {
+                return;
+            }
         }
     }
 

--- a/Classes/KWReceiveMatcher.m
+++ b/Classes/KWReceiveMatcher.m
@@ -148,6 +148,7 @@ static NSString * const StubValueKey = @"StubValueKey";
     @try {
 #endif // #if KW_TARGET_HAS_INVOCATION_EXCEPTION_BUG
 
+    [self.subject stubMessagePattern:aMessagePattern andReturn:nil overrideExisting:NO];
     self.messageTracker = [KWMessageTracker messageTrackerWithSubject:self.subject messagePattern:aMessagePattern countType:aCountType count:aCount];
 
 #if KW_TARGET_HAS_INVOCATION_EXCEPTION_BUG

--- a/Classes/NSObject+KiwiStubAdditions.h
+++ b/Classes/NSObject+KiwiStubAdditions.h
@@ -26,6 +26,7 @@
 - (id)stubAndReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue;
 
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue;
+- (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue overrideExisting:(BOOL)overrideExisting;
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue;
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern withBlock:(id (^)(NSArray *params))block;
 

--- a/Classes/NSObject+KiwiStubAdditions.m
+++ b/Classes/NSObject+KiwiStubAdditions.m
@@ -90,18 +90,22 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 }
 
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue {
+    [self stubMessagePattern:aMessagePattern andReturn:aValue overrideExisting:YES];
+}
+
+- (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue overrideExisting:(BOOL)overrideExisting {
     if ([self methodSignatureForSelector:aMessagePattern.selector] == nil) {
         [NSException raise:@"KWStubException" format:@"cannot stub -%@ because no such method exists",
-                                                     NSStringFromSelector(aMessagePattern.selector)];
+         NSStringFromSelector(aMessagePattern.selector)];
     }
-
+    
     Class interceptClass = KWSetupObjectInterceptSupport(self);
     KWSetupMethodInterceptSupport(interceptClass, aMessagePattern.selector);
     KWStub *stub = [KWStub stubWithMessagePattern:aMessagePattern value:aValue];
-    KWAssociateObjectStub(self, stub);
+    KWAssociateObjectStub(self, stub, overrideExisting);
 }
 
-- (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue {   
+- (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue {
     if ([self methodSignatureForSelector:aMessagePattern.selector] == nil) {
         [NSException raise:@"KWStubException" format:@"cannot stub -%@ because no such method exists",
          NSStringFromSelector(aMessagePattern.selector)];
@@ -110,7 +114,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     Class interceptClass = KWSetupObjectInterceptSupport(self);
     KWSetupMethodInterceptSupport(interceptClass, aMessagePattern.selector);
     KWStub *stub = [KWStub stubWithMessagePattern:aMessagePattern value:aValue times:times afterThatReturn:aSecondValue];
-    KWAssociateObjectStub(self, stub);
+    KWAssociateObjectStub(self, stub, YES);
 }
 
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern withBlock:(id (^)(NSArray *params))block {
@@ -122,7 +126,7 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     Class interceptClass = KWSetupObjectInterceptSupport(self);
     KWSetupMethodInterceptSupport(interceptClass, aMessagePattern.selector);
     KWStub *stub = [KWStub stubWithMessagePattern:aMessagePattern block:block];
-    KWAssociateObjectStub(self, stub);
+    KWAssociateObjectStub(self, stub, YES);
 }
 
 - (void)clearStubs {

--- a/Tests/KWReceiveMatcherTest.m
+++ b/Tests/KWReceiveMatcherTest.m
@@ -84,6 +84,23 @@
     STAssertFalse([matcher evaluate], @"expected negative match");
 }
 
+- (void)testItShouldStubForReceive {
+    id subject  = [Cruiser cruiser];
+    id matcher = [KWReceiveMatcher matcherWithSubject:subject];
+    [matcher receive:@selector(crewComplement)];
+    NSUInteger value = [subject crewComplement];
+    STAssertTrue(value == 0, @"expected method to be stubbed");
+}
+
+- (void)testItShouldNotOverrideExistingStub {
+    id subject  = [Cruiser cruiser];
+    [subject stub:@selector(crewComplement) andReturn:[KWValue valueWithUnsignedInt:333]];
+    id matcher = [KWReceiveMatcher matcherWithSubject:subject];
+    [matcher receive:@selector(crewComplement)];
+    NSUInteger value = [subject crewComplement];
+    STAssertTrue(value == 333, @"expected receive not to override existing stub");
+}
+
 - (void)testItShouldStubForReceiveAndReturn {
     id subject = [Cruiser cruiser];
     id matcher = [KWReceiveMatcher matcherWithSubject:subject];


### PR DESCRIPTION
It does not override an existing stub, if you have manually stubbed the message before.
