### PR TITLE
Added support for partial mocks

### DIFF
--- a/Classes/KWMock.h
+++ b/Classes/KWMock.h
@@ -15,8 +15,10 @@
 
 @interface KWMock : NSObject {
 @private
+    BOOL isPartialMock;
     BOOL isNullMock;
     NSString *mockName;
+    id mockedObject;
     Class mockedClass;
     Protocol *mockedProtocol;
     NSMutableArray *stubs;
@@ -37,6 +39,9 @@
 - (id)initAsNullMockWithName:(NSString *)aName forClass:(Class)aClass;
 - (id)initAsNullMockWithName:(NSString *)aName forProtocol:(Protocol *)aProtocol;
 
+- (id)initAsPartialMockForObject:(id)object;
+- (id)initAsPartialMockWithName:(NSString *)aName forObject:(id)object;
+
 + (id)mockForClass:(Class)aClass;
 + (id)mockForProtocol:(Protocol *)aProtocol;
 + (id)mockWithName:(NSString *)aName forClass:(Class)aClass;
@@ -47,12 +52,17 @@
 + (id)nullMockWithName:(NSString *)aName forClass:(Class)aClass ;
 + (id)nullMockWithName:(NSString *)aName forProtocol:(Protocol *)aProtocol;
 
++ (id)partialMockForObject:(id)object;
++ (id)partialMockWithName:(NSString *)aName forObject:(id)object;
+
 #pragma mark -
 #pragma mark Properties
 
 @property (nonatomic, readonly) BOOL isNullMock;
+@property (nonatomic, readonly) BOOL isPartialMock;
 @property (nonatomic, readonly) NSString *mockName;
 @property (nonatomic, readonly) Class mockedClass;
+@property (nonatomic, readonly) id mockedObject;
 @property (nonatomic, readonly) Protocol *mockedProtocol;
 
 #pragma mark -

--- a/Classes/KWMock.m
+++ b/Classes/KWMock.m
@@ -114,6 +114,18 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     return self;
 }
 
+- (id)initAsPartialMockForObject:(id)object {
+    return [self initAsPartialMockWithName:nil forObject:object];
+}
+
+- (id)initAsPartialMockWithName:(NSString *)aName forObject:(id)object {
+    if ((self = [self initAsNullMock:YES withName:aName forClass:[object class] protocol:nil])) {
+        isPartialMock = YES;
+        mockedObject = [object retain];
+    }
+    return self;
+}
+
 + (id)mockForClass:(Class)aClass {
     return [[[self alloc] initForClass:aClass] autorelease];
 }
@@ -146,7 +158,16 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     return [[[self alloc] initAsNullMockWithName:aName forProtocol:aProtocol] autorelease];
 }
 
++ (id)partialMockWithName:(NSString *)aName forObject:(id)object {
+    return [[[self alloc] initAsPartialMockWithName:aName forObject:object] autorelease];
+}
+
++ (id)partialMockForObject:(id)object {
+    return [[[self alloc] initAsPartialMockForObject:object] autorelease];
+}
+
 - (void)dealloc {
+    [mockedObject release];
     [mockName release];
     [stubs release];
     [expectedMessagePatterns release];
@@ -157,8 +178,10 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 #pragma mark -
 #pragma mark Properties
 
+@synthesize isPartialMock;
 @synthesize isNullMock;
 @synthesize mockName;
+@synthesize mockedObject;
 @synthesize mockedClass;
 @synthesize mockedProtocol;
 @synthesize stubs;
@@ -441,6 +464,9 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 
     if ([self processReceivedInvocation:anInvocation])
         return;
+
+    if (isPartialMock)
+        [anInvocation invokeWithTarget:self.mockedObject];
 
     if (self.isNullMock)
         return;

--- a/Tests/KWMockTest.m
+++ b/Tests/KWMockTest.m
@@ -42,6 +42,23 @@
     STAssertEqualObjects([mock mockName], @"JumpCapable mock", @"expected class mock to have the correct mockName");
 }
 
+- (void)testItShouldInitializeAPartialMockForAClass {
+    id mockedObject = [[Cruiser alloc] init];
+    id name = @"Cruiser mock";
+    id mock = [KWMock partialMockWithName:name forObject:mockedObject];
+    STAssertNotNil(mock, @"expected a mock object to be initialized");
+    STAssertEqualObjects([mock mockedObject], mockedObject, @"expected the mockedClass property to be set");
+    STAssertTrue([mock isPartialMock], @"expected the isPartialMock property to be set");
+}
+
+- (void)testItShouldPassThroughAMessageToTheMockedObjectAsAPartialMock {
+    id callsign = @"Object Callsign";
+    id mockedObject = [[Cruiser alloc] initWithCallsign:callsign];
+    id mock = [KWMock partialMockForObject:mockedObject];
+    id returnedCallsign = [mock callsign];
+    STAssertEqualObjects(returnedCallsign, callsign, @"expected the partial mock to pass through a message to the object");
+}
+
 //- (void)testItShouldRaiseWhenReceivingUnexpectedMessageAsAMock {
 //    id mock = [KWMock mockForClass:[Cruiser class]];
 //    STAssertThrows([mock objectAtIndex:0], @"expected mock to raise exception");
@@ -142,6 +159,13 @@
     STAssertEquals([mock hash], 4242u, @"expected method to be stubbed");
     STAssertEqualObjects([mock description], @"king rat", @"expected method to be stubbed");
     STAssertEqualObjects([mock copy], @"bacon", @"expected method to be stubbed");
+}
+
+- (void)testItShouldStubWithAsAPartialMock {
+    id mockedObject = [[Cruiser alloc] initWithCallsign:@"asdf"];
+    id mock = [KWMock partialMockForObject:mockedObject];
+    [mock stub:@selector(callsign) andReturn:@"test callsign"];
+    STAssertEqualObjects([mock callsign], @"test callsign", @"expected the partial mock to hit a stub when defined");
 }
 
 - (void)testItShouldNotRaiseForWhitelistedMethods {


### PR DESCRIPTION
Allows partial mocks which will forward any invocations to the object it mocks if the method is not stubbed (feature of OCMock). Really helpful when adding tests to some code that was not originally designed for automated testing.
