### PR TITLE
Convert stub nil arguments to NSNull before adding to params array

### DIFF
--- a/Classes/KWStub.m
+++ b/Classes/KWStub.m
@@ -185,6 +185,10 @@
 			
 			const char *argType = [[anInvocation methodSignature] getArgumentTypeAtIndex:i];
 			if (strcmp(argType, "@?") == 0) arg = [[arg copy] autorelease];
+            
+            if (arg == nil)
+                arg = [NSNull null];
+            
 			[args addObject:arg];
 		}
 		

--- a/Tests/KWStubTest.m
+++ b/Tests/KWStubTest.m
@@ -77,6 +77,20 @@
     STAssertEquals(result.callsign, @"Red Leader", @"expected stub to perform given block");
 }
 
+- (void)testItShouldPerformStubbedBlockWhenInvocationHasNilArguments {
+    id subject = [Cruiser cruiser];
+    KWMessagePattern *messagePattern = [KWMessagePattern messagePatternWithSelector:@selector(fighterWithCallsign:)];
+    id stub = [KWStub stubWithMessagePattern:messagePattern block: (id) ^(NSArray *params) {
+        return [[params copy] autorelease];
+    }];
+    NSInvocation *invocation = [NSInvocation invocationWithTarget:subject selector:@selector(fighterWithCallsign:) messageArguments:nil];
+    [stub processInvocation:invocation];
+    id outcome = nil;
+    [invocation getReturnValue:&outcome];
+    NSArray *result = (NSArray *)outcome;
+    STAssertEquals([result objectAtIndex:0], [NSNull null], @"expected stub convert nil arguments to NSNull");
+}
+
 - (void)testItShouldRetainValueWhenProcessingInvocationsThatBeginsWithAlloc {
     id subject = [Cruiser mock];
     id messagePattern = [KWMessagePattern messagePatternWithSelector:@selector(alloc)];


### PR DESCRIPTION
Stubbing a method that is called with nil arguments currently fails because [KWStub attempts to add nil to an array](https://github.com/allending/Kiwi/blob/master/Classes/KWStub.m#L184-L188). 

The following method:

```
- (void)someMethod
{
    [otherObject someOtherMethodWithNilArgument:nil];
}
```

stubbed using:

```
[otherObjectMock stub:@selector(someMethod) withBlock:^id(NSArray *theArguments) {
    // Do something   
}
```

will never call the block because an attempt is made to add nil to an array which raises an exception which is [caught](https://github.com/allending/Kiwi/blob/master/Classes/KWMock.m#L485) by `KWMock`. 

This PR fixes the issue by inserting `NSNull` in stead of nil into the array.
