### PR TITLE
Add support for matchPattern:options:

### DIFF
--- a/Classes/KWRegularExpressionPatternMatcher.h
+++ b/Classes/KWRegularExpressionPatternMatcher.h
@@ -13,4 +13,6 @@
 
 - (void)matchPattern:(NSString *)pattern;
 
+- (void)matchPattern:(NSString *)pattern options:(NSRegularExpressionOptions)options;
+
 @end

--- a/Classes/KWRegularExpressionPatternMatcher.m
+++ b/Classes/KWRegularExpressionPatternMatcher.m
@@ -13,6 +13,7 @@
 @interface KWRegularExpressionPatternMatcher ()
 
 @property (nonatomic, copy) NSString *pattern;
+@property (nonatomic) NSRegularExpressionOptions options;
 
 @end
 
@@ -28,7 +29,7 @@
 #pragma mark Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return @[@"matchPattern:"];
+    return @[@"matchPattern:", @"matchPattern:options:"];
 }
 
 #pragma mark -
@@ -43,7 +44,7 @@
     
     NSError *error = nil;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:self.pattern
-                                                                           options:0
+                                                                           options:self.options
                                                                              error:&error];
     if (!regex) {
         NSLog(@"%s: Unable to create regular expression for pattern \"%@\": %@",
@@ -77,6 +78,12 @@
 
 - (void)matchPattern:(NSString *)pattern {
     self.pattern = pattern;
+    self.options = 0;
+}
+
+- (void)matchPattern:(NSString *)pattern options:(NSRegularExpressionOptions)options {
+    self.pattern = pattern;
+    self.options = options;
 }
 
 @end

--- a/Tests/KWRegularExpressionPatternMatcherTest.m
+++ b/Tests/KWRegularExpressionPatternMatcherTest.m
@@ -20,7 +20,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWRegularExpressionPatternMatcher matcherStrings];
-    NSArray *expectedStrings = @[@"matchPattern:"];
+    NSArray *expectedStrings = @[@"matchPattern:", @"matchPattern:options:"];
     STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
@@ -51,6 +51,20 @@
     id subject = @"ababab";
     id matcher = [KWRegularExpressionPatternMatcher matcherWithSubject:subject];
     [matcher matchPattern:@"(abc)+"];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+- (void)testItShouldMatchCaseInsensitive {
+    id subject = @"abABab";
+    id matcher = [KWRegularExpressionPatternMatcher matcherWithSubject:subject];
+    [matcher matchPattern:@"(ab)+" options:NSRegularExpressionCaseInsensitive];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldNotMatchCaseInsensitive {
+    id subject = @"abABab";
+    id matcher = [KWRegularExpressionPatternMatcher matcherWithSubject:subject];
+    [matcher matchPattern:@"(abc)+" options:NSRegularExpressionCaseInsensitive];
     STAssertFalse([matcher evaluate], @"expected negative match");
 }
 


### PR DESCRIPTION
This commit enhances the KWRegularExpressionPatternMatcher class to support specifying NSRegularExpressionOptions in an expectation.  For example:

```
it(@"succeeds with NSRegularExpressionCaseInsensitive option", ^{
    [[@"abABab" should] matchPattern:@"(ab)+" options:NSRegularExpressionCaseInsensitive];
});

it(@"fails with non-matching NSRegularExpressionCaseInsensitive option", ^{
    [[@"abABab" shouldNot] matchPattern:@"(abc)+" options:NSRegularExpressionCaseInsensitive];
});
```
