### PR TITLE
Asynchronous to synchronous function helpers 

### DIFF
--- a/KWStep.h
+++ b/KWStep.h
@@ -1,0 +1,12 @@
+//
+// Created by rael on 16/04/2013.
+//
+
+#import <Foundation/Foundation.h>
+#import "KWBlock.h"
+
+typedef void (^KWStepBlock)(id);
+
+@protocol KWStep <NSObject>
+
+@end

--- a/KWStepFunction.h
+++ b/KWStepFunction.h
@@ -1,0 +1,51 @@
+//
+// Created by rael on 16/04/2013.
+//
+
+#import <Foundation/Foundation.h>
+#import <Kiwi/KWBlock.h>
+#import "KWStep.h"
+
+
+
+id exec(NSObject <KWStep> *target, SEL selector, id object2) {
+    assert([target respondsToSelector:selector]);
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    __block id returnVal;
+    KWStepBlock aBlock = ^(id val){
+        dispatch_semaphore_signal(semaphore);
+        returnVal = val;
+    };
+
+    if (object2){
+        [target performSelector:selector withObject:aBlock withObject:object2];
+    } else {
+        [target performSelector:selector withObject:aBlock];
+    }
+
+    while (dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW))
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+
+    return returnVal;
+}
+
+void stepAndWait(NSObject <KWStep> *target, SEL selector, id object2) {
+    assert([target respondsToSelector:selector]);
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    id aBlock = ^{ dispatch_semaphore_signal(semaphore);};
+
+    if (object2){
+        [target performSelector:selector withObject:aBlock withObject:object2];
+    } else {
+        [target performSelector:selector withObject:aBlock];
+    }
+
+    while (dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW))
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+}


### PR DESCRIPTION
The two additions (stepAndWait and exec) allow an asynchronous function to be tested in a synchronous manner. I am currently using it for Integration Testing a Restful web-service, with RestKit and AFNetworking as the underlying framework. 

Example:

I have the following helper class, 
     `@interface SyncSteps : NSObject <KWStep>`
In my test, I have an instance of SyncSteps
     `__block SyncSteps *syncSteps = [[SyncSteps alloc] init];`

test code:

``` objective-c
UserSettings *userSettings = exec(syncSteps, @selector(getUserSetting:), nil);
[[theValue(userSettings.intervalSetting) should] equal:theValue(kDaily)];

[userSettings setIntervalSetting:kWeekly]
stepAndWait(syncSteps, @selector(setUserSetting:userSettings:), userSettings);

userSettings = exec(syncSteps, @selector(getUserSetting:), nil);
[[theValue(userSettings.intervalSetting) should] equal:theValue(kWeekly)]
```

SyncSteps functions: 

``` objective-c
-(void) getUserSetting:(KWStepBlock)block  {
    [ProfileController
        getUserSettingsWithSuccess:^(UserSettings *userSettings){
            block(userSettings);
        }retry:^(int retryCount) {
            NSLog(@"retry %d", retryCount);
        } failure:^{
            NSLog(@"fail");
        }
    ];
}

-(void) setUserSetting:(KWVoidBlock)block userSettings:(UserSettings *)userSettings {
    [ProfileController setUserSetting:userSettings
        success:^{
            block();
        } retry:^(int retryCount) {
            NSLog(@"retry %d", retryCount);
        } failure:^{
            NSLog(@"fail");
        }
    ];
}
```

Thus, **all** functions which return nothing have **KWVoidBlock** as the **first** parameter, and **all** functions which return a value asynchronously have **KWStepBlock** as the **first** parameter.

Both exec and stepAndWait take either nil or an object as the second parameter, which is used to pass in parameters to the helper function. An array can be used if more than one extra parameter is needed.

e.,g, 
    stepAndWait(syncSteps, @selector(setUserSetting:userSettings:), @[userID, userSettings]);

```
-(void) setUserSetting:(KWVoidBlock)block userSettings:(NSArray *)args 
```

Unfortunately the best mechanism for failing on the retry and failure blocks above, is to call block() or (nil) to prevent the test running forever. 
