### PR TITLE
Add KWContainStringMatcher

### DIFF
--- a/Classes/KWContainStringMatcher.h
+++ b/Classes/KWContainStringMatcher.h
@@ -1,0 +1,39 @@
+//
+//  KWContainStringMatcher.h
+//  Kiwi
+//
+//  Created by Kristopher Johnson on 4/28/13.
+//  Copyright (c) 2013 Allen Ding. All rights reserved.
+//
+
+#import "KiwiConfiguration.h"
+#import "KWMatcher.h"
+
+// Kiwi matcher for determining whether a string contains an expected substring
+//
+// Examples:
+//
+//     [[@"Hello, world!" should] containString:@"world"];
+//     [[@"Hello, world!" shouldNot] containString:@"xyzzy"];
+//
+//     [[@"Hello, world!" should] containString:@"WORLD"
+//                                      options:NSCaseInsensitiveSearch];
+//
+//     [[@"Hello, world!" should] startWithString:@"Hello,"];
+//     [[@"Hello, world!" should] endWithString:@"world!"];
+
+@interface KWContainStringMatcher : KWMatcher
+
+// Match if subject contains specified substring
+- (void)containString:(NSString *)string;
+
+// Match if subject contains specified substring, using specified comparison options
+- (void)containString:(NSString *)string options:(NSStringCompareOptions)options;
+
+// Match if subject starts with the specified prefix
+- (void)startWithString:(NSString *)prefix;
+
+// Match if subject ends with the specified prefix
+- (void)endWithString:(NSString *)suffix;
+
+@end

--- a/Classes/KWContainStringMatcher.m
+++ b/Classes/KWContainStringMatcher.m
@@ -1,0 +1,89 @@
+//
+//  KWContainStringMatcher.m
+//  Kiwi
+//
+//  Created by Kristopher Johnson on 4/28/13.
+//  Copyright (c) 2013 Allen Ding. All rights reserved.
+//
+
+#import "KWContainStringMatcher.h"
+#import "KWFormatter.h"
+
+@interface KWContainStringMatcher ()
+
+@property (nonatomic, copy) NSString *substring;
+@property (nonatomic) NSStringCompareOptions options;
+
+@end
+
+
+@implementation KWContainStringMatcher
+
+#pragma mark -
+#pragma mark Getting Matcher Strings
+
++ (NSArray *)matcherStrings {
+    return @[@"containString:",
+             @"containString:options:",
+             @"startWithString:",
+             @"endWithString:"];
+}
+
+#pragma mark -
+#pragma mark Matching
+
+- (BOOL)evaluate {
+    NSString *subjectString = (NSString *)self.subject;
+    if (![subjectString isKindOfClass:[NSString class]]) {
+        [NSException raise:@"KWMatcherException" format:@"subject is not a string"];
+        return NO;
+    }
+    
+    NSRange range = [subjectString rangeOfString:self.substring options:self.options];
+    return (range.location != NSNotFound);
+}
+
+#pragma mark -
+#pragma mark Getting Failure Messages
+
+- (NSString *)failureMessageForShould {
+    return [NSString stringWithFormat:@"%@ did not contain string \"%@\"",
+            [KWFormatter formatObject:self.subject],
+            self.substring];
+}
+
+- (NSString *)failureMessageForShouldNot {
+    return [NSString stringWithFormat:@"expected subject not to contain string \"%@\"",
+            self.substring];
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"contain substring \"%@\"", self.substring];
+}
+
+#pragma mark -
+#pragma mark Configuring matchers
+
+- (void)containString:(NSString *)substring {
+    self.substring = substring;
+    self.options = 0;
+}
+
+- (void)containString:(NSString *)substring options:(NSStringCompareOptions)options {
+    self.substring = substring;
+    self.options = options;
+}
+
+- (void)startWithString:(NSString *)prefix {
+    self.substring = prefix;
+    self.options = NSAnchoredSearch;
+}
+
+- (void)endWithString:(NSString *)suffix {
+    self.substring = suffix;
+    self.options = NSAnchoredSearch | NSBackwardsSearch;
+}
+
+@end
+
+

--- a/Classes/Kiwi.h
+++ b/Classes/Kiwi.h
@@ -36,6 +36,7 @@ extern "C" {
 #import "KWChangeMatcher.h"
 #import "KWConformToProtocolMatcher.h"
 #import "KWContainMatcher.h"
+#import "KWContainStringMatcher.h"
 #import "KWContextNode.h"
 #import "KWDeviceInfo.h"
 #import "KWEqualMatcher.h"

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -122,6 +122,11 @@
 		4E3C5DB41716C34900835B62 /* KWRegularExpressionPatternMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E3C5DB11716C34900835B62 /* KWRegularExpressionPatternMatcher.m */; };
 		4E3C5DB51716C34900835B62 /* KWRegularExpressionPatternMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E3C5DB11716C34900835B62 /* KWRegularExpressionPatternMatcher.m */; };
 		4E3C5DB81716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E3C5DB71716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m */; };
+		4E7659AA172DAC6500105B93 /* KWContainStringMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E7659A8172DAC6500105B93 /* KWContainStringMatcher.h */; };
+		4E7659AB172DAC6500105B93 /* KWContainStringMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7659A9172DAC6500105B93 /* KWContainStringMatcher.m */; };
+		4E7659AC172DAC8E00105B93 /* KWContainStringMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E7659A8172DAC6500105B93 /* KWContainStringMatcher.h */; };
+		4E7659AD172DAC9100105B93 /* KWContainStringMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7659A9172DAC6500105B93 /* KWContainStringMatcher.m */; };
+		4E7659B0172DAE4D00105B93 /* KWContainStringMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E7659AF172DAE4D00105B93 /* KWContainStringMatcherTest.m */; };
 		511901A516A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
 		511901A616A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
 		511901A716A95CDE006E7359 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 511901A416A95CDE006E7359 /* KWChangeMatcher.m */; };
@@ -641,6 +646,9 @@
 		4E3C5DB01716C34900835B62 /* KWRegularExpressionPatternMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KWRegularExpressionPatternMatcher.h; path = Classes/KWRegularExpressionPatternMatcher.h; sourceTree = "<group>"; };
 		4E3C5DB11716C34900835B62 /* KWRegularExpressionPatternMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KWRegularExpressionPatternMatcher.m; path = Classes/KWRegularExpressionPatternMatcher.m; sourceTree = "<group>"; };
 		4E3C5DB71716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWRegularExpressionPatternMatcherTest.m; sourceTree = "<group>"; };
+		4E7659A8172DAC6500105B93 /* KWContainStringMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KWContainStringMatcher.h; path = Classes/KWContainStringMatcher.h; sourceTree = "<group>"; };
+		4E7659A9172DAC6500105B93 /* KWContainStringMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KWContainStringMatcher.m; path = Classes/KWContainStringMatcher.m; sourceTree = "<group>"; };
+		4E7659AF172DAE4D00105B93 /* KWContainStringMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWContainStringMatcherTest.m; sourceTree = "<group>"; };
 		511901A016A95803006E7359 /* KWChangeMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWChangeMatcherTest.m; sourceTree = "<group>"; };
 		511901A316A95CDE006E7359 /* KWChangeMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KWChangeMatcher.h; path = Classes/KWChangeMatcher.h; sourceTree = "<group>"; };
 		511901A416A95CDE006E7359 /* KWChangeMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KWChangeMatcher.m; path = Classes/KWChangeMatcher.m; sourceTree = "<group>"; };
@@ -1122,6 +1130,8 @@
 				9F982C6C16A802920030A0B1 /* KWConformToProtocolMatcher.m */,
 				9F982C6D16A802920030A0B1 /* KWContainMatcher.h */,
 				9F982C6E16A802920030A0B1 /* KWContainMatcher.m */,
+				4E7659A8172DAC6500105B93 /* KWContainStringMatcher.h */,
+				4E7659A9172DAC6500105B93 /* KWContainStringMatcher.m */,
 				9F982C6F16A802920030A0B1 /* KWContextNode.h */,
 				9F982C7016A802920030A0B1 /* KWContextNode.m */,
 				9F982C7116A802920030A0B1 /* KWCountType.h */,
@@ -1305,19 +1315,20 @@
 				F58F5877117DAC1800D05908 /* KWBeTrueMatcherTest.m */,
 				F5A1E67811743B92002223E1 /* KWBeWithinMatcherTest.m */,
 				F5E9FC8411AE6E740089BACE /* KWBlockRaiseMatcherTest.m */,
+				511901A016A95803006E7359 /* KWChangeMatcherTest.m */,
 				F54A4C0011734975002442C5 /* KWConformToProtocolMatcherTest.m */,
 				F53B5E42115B33FC0022BC0B /* KWContainMatcherTest.m */,
+				4E7659AF172DAE4D00105B93 /* KWContainStringMatcherTest.m */,
 				F53B5E65115B36EB0022BC0B /* KWEqualMatcherTest.m */,
+				A352EA1A12EDC8380049C691 /* KWGenericMatcherTest.m */,
 				F553B48A1175B238004FCA2E /* KWHaveMatcherTest.m */,
+				A352E9E712EDC30A0049C691 /* KWHaveValueMatcherTest.m */,
 				F553B29D11755A00004FCA2E /* KWInequalityMatcherTest.m */,
 				F53B5EC5115B3D180022BC0B /* KWRaiseMatcherTest.m */,
 				F5C36E91115C9F0700425FDA /* KWReceiveMatcherTest.m */,
-				F553B6641175D48C004FCA2E /* KWRespondToSelectorMatcherTest.m */,
-				A352E9E712EDC30A0049C691 /* KWHaveValueMatcherTest.m */,
-				A352EA1A12EDC8380049C691 /* KWGenericMatcherTest.m */,
-				A385CAE713AA7EA200DCA951 /* KWUserDefinedMatcherTest.m */,
-				511901A016A95803006E7359 /* KWChangeMatcherTest.m */,
 				4E3C5DB71716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m */,
+				F553B6641175D48C004FCA2E /* KWRespondToSelectorMatcherTest.m */,
+				A385CAE713AA7EA200DCA951 /* KWUserDefinedMatcherTest.m */,
 			);
 			name = Matchers;
 			sourceTree = "<group>";
@@ -1432,6 +1443,7 @@
 				9F90FBF116BA5FF20057426D /* KWGenericMatchEvaluator.h in Headers */,
 				9F820DB916BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h in Headers */,
 				4E3C5DB31716C34900835B62 /* KWRegularExpressionPatternMatcher.h in Headers */,
+				4E7659AC172DAC8E00105B93 /* KWContainStringMatcher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1533,6 +1545,7 @@
 				9F90FBF016BA5FF20057426D /* KWGenericMatchEvaluator.h in Headers */,
 				9F820DB816BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h in Headers */,
 				4E3C5DB21716C34900835B62 /* KWRegularExpressionPatternMatcher.h in Headers */,
+				4E7659AA172DAC6500105B93 /* KWContainStringMatcher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1782,6 +1795,7 @@
 				9F90FBF316BA5FF20057426D /* KWGenericMatchEvaluator.m in Sources */,
 				9F820DBB16BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.m in Sources */,
 				4E3C5DB51716C34900835B62 /* KWRegularExpressionPatternMatcher.m in Sources */,
+				4E7659AD172DAC9100105B93 /* KWContainStringMatcher.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1868,6 +1882,7 @@
 				9F90FBF216BA5FF20057426D /* KWGenericMatchEvaluator.m in Sources */,
 				9F820DBA16BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.m in Sources */,
 				4E3C5DB41716C34900835B62 /* KWRegularExpressionPatternMatcher.m in Sources */,
+				4E7659AB172DAC6500105B93 /* KWContainStringMatcher.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1925,6 +1940,7 @@
 				89861D9416FE0EE5008CE99D /* KWFormatterTest.m in Sources */,
 				C10F0370170C7C2D0031FE64 /* KWBeSubclassOfClassMatcherTest.m in Sources */,
 				4E3C5DB81716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m in Sources */,
+				4E7659B0172DAE4D00105B93 /* KWContainStringMatcherTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/KWContainStringMatcherTest.m
+++ b/Tests/KWContainStringMatcherTest.m
@@ -1,0 +1,93 @@
+//
+//  KWContainStringMatcherTest.m
+//  Kiwi
+//
+//  Created by Kristopher Johnson on 4/28/13.
+//  Copyright (c) 2013 Allen Ding. All rights reserved.
+//
+
+#import "Kiwi.h"
+#import "KiwiTestConfiguration.h"
+#import "TestClasses.h"
+
+#if KW_TESTS_ENABLED
+
+@interface KWContainStringMatcherTest : SenTestCase
+
+@end
+
+@implementation KWContainStringMatcherTest
+
+- (void)testItShouldHaveTheRightMatcherStrings {
+    NSArray *matcherStrings = [KWContainStringMatcher matcherStrings];
+    NSArray *expectedStrings = @[@"containString:", @"containString:options:", @"startWithString:", @"endWithString:"];
+    STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
+                         [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
+                         @"expected specific matcher strings");
+}
+
+- (void)testItShouldHaveHumanReadableDescription {
+    id matcher = [KWContainStringMatcher matcherWithSubject:@"test subject"];
+    [matcher containString:@"foo"];
+    STAssertEqualObjects([matcher description], @"contain substring \"foo\"", @"expected description to match");
+}
+
+- (void)testItShouldMatchSubstring {
+    id subject = @"Transylvania";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher containString:@"sylvan"];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldNotMatchIfNoSuchSubstring {
+    id subject = @"Hot dog";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher containString:@"pup"];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+- (void)testItShouldNotMatchIfCaseDoesNotMatch {
+    id subject = @"Transylvania";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher containString:@"SYLVAN"];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+- (void)testItShouldMatchSubstringWithCaseInsensitiveOption {
+    id subject = @"Transylvania";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher containString:@"SYLVAN" options:NSCaseInsensitiveSearch];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldMatchPrefix {
+    id subject = @"Hot dog";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher startWithString:@"Hot"];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldNotMatchMissingPrefix {
+    id subject = @"Hot dog";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher startWithString:@"ot"];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+- (void)testItShouldMatchSuffix {
+    id subject = @"Hot dog";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher endWithString:@"dog"];
+    STAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldNotMatchMissingSuffix {
+    id subject = @"Hot dog";
+    id matcher = [KWContainStringMatcher matcherWithSubject:subject];
+    [matcher endWithString:@"do"];
+    STAssertFalse([matcher evaluate], @"expected negative match");
+}
+
+@end
+
+#endif // #if KW_TESTS_ENABLED


### PR DESCRIPTION
Adds new matcher class, KWContainStringMatcher, to support expectations `containString:`, `containString:options:`, `startWithString:`, and `endWithString:`.

Example usage:

```
 [[@"Hello, world!" should] containString:@"world"];
 [[@"Hello, world!" shouldNot] containString:@"xyzzy"];

 [[@"Hello, world!" should] containString:@"WORLD" options:NSCaseInsensitiveSearch];

 [[@"Hello, world!" should] startWithString:@"Hello,"];
 [[@"Hello, world!" should] endWithString:@"world!"];
```

For more details and examples, see https://gist.github.com/kristopherjohnson/5478039
