### PR TITLE
Added Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: objective-c
+before_install:
+  - brew update
+  - brew install xctool
+script: xctool test

--- a/.xctool-args
+++ b/.xctool-args
@@ -1,0 +1,4 @@
+[
+  "-project", "Kiwi.xcodeproj",
+  "-scheme", "Kiwi"
+]

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,6 @@
 # Simple BDD for iOS #
+[![Build Status](https://travis-ci.org/allending/Kiwi.png?branch=master)](https://travis-ci.org/allending/Kiwi)
+
 Kiwi is a Behavior Driven Development library for iOS development.
 The goal is to provide a BDD library that is exquisitely simple to setup and use.
 


### PR DESCRIPTION
As [Travis CI](https://travis-ci.org) now supports objective-c and [xctool](https://github.com/facebook/xctool), which allows to run tests from CLI with ease, is released. It's super easy to have continuous integration for open source projects! :)

I'm happy to propose to add support for Travis CI for Kiwi! :) With these changes each time when somebody pushes something all tests will be run on Travis CI. In case of failure notifications will be sent.

Example of test results can be found [here](https://travis-ci.org/yas375/Kiwi).

Also it is needed to enable Travis CI hook for the repository on Github. The easiest way to do this is to login into [Travis CI](https://travis-ci.org) with Github account. On [profile page](https://travis-ci.org/profile) enable sync for `allending/Kiwi` repository. And that's all! :)
