### PR TITLE
Fix for Xcode conversion warning when targeting for OS X

### DIFF
--- a/Classes/KWStub.m
+++ b/Classes/KWStub.m
@@ -182,7 +182,7 @@
 		NSUInteger numberOfArguments = [[anInvocation methodSignature] numberOfArguments];
 		NSMutableArray *args = [NSMutableArray arrayWithCapacity:(numberOfArguments-2)];
 		for (NSUInteger i = 2; i < numberOfArguments; ++i) {
-			id arg = [anInvocation getArgumentAtIndexAsObject:i];
+			id arg = [anInvocation getArgumentAtIndexAsObject:(int)i];
 			
 			const char *argType = [[anInvocation methodSignature] getArgumentTypeAtIndex:i];
 			if (strcmp(argType, "@?") == 0) arg = [[arg copy] autorelease];


### PR DESCRIPTION
When targeting for OS X 10.8 SDK, Xcode displays the following error in `KWStub.m:185`:

> KWStub.m:185:54: Implicit conversion loses integer precision: 'NSUInteger' (aka 'unsigned long') to 'int'

The simple typecasting solves the problem.
