### PR TITLE
Fixed: Xcode template install fails because path includes a space

### DIFF
--- a/Xcode Templates/install-templates.sh
+++ b/Xcode Templates/install-templates.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-SOURCE_DIR=$(dirname $0)
+SOURCE_DIR=$(dirname "$0")
 TEMPLATES_DIR="$HOME/Library/Developer/Xcode/Templates"
 FILE_TEMPLATES_DIR="$TEMPLATES_DIR/File Templates"
 KIWI_TEMPLATES_DIR="$FILE_TEMPLATES_DIR/Kiwi"


### PR DESCRIPTION
The install-templates.sh script is failing because the argument to the `dirname` command will include a space (because the directory "Xcode Templates" is part of the path to the script) and the variable is not in quotes. After adding quotes around the argument, the script works again.

(Yes, this is a really tiny fix, but just because it was easy doesn't mean it isn't worth doing.) :-)
