### PR TITLE
Add `its` example group builder

### DIFF
--- a/Classes/Core/KWExample.h
+++ b/Classes/Core/KWExample.h
@@ -67,6 +67,7 @@ void afterAll(void (^block)(void));
 void beforeEach(void (^block)(void));
 void afterEach(void (^block)(void));
 void it(NSString *aDescription, void (^block)(void));
+void its(NSString *aDescription, void (^block)(void));
 void specify(void (^block)(void));
 void pending_(NSString *aDescription, void (^block)(void));
 

--- a/Classes/Core/KWExample.m
+++ b/Classes/Core/KWExample.m
@@ -321,6 +321,10 @@ void it(NSString *aDescription, void (^block)(void)) {
     itWithCallSite(callSite, aDescription, block);
 }
 
+void its(NSString *aDescription, void (^block)(void)) {
+    it(aDescription, block);
+}
+
 void specify(void (^block)(void))
 {
     itWithCallSite(nil, nil, block);


### PR DESCRIPTION
- Just an 'alias' to the existing `it`

This is to improve the readability of a spec in some cases, like:

```
describe(@"MyCustomSlider", ^{
    context(@"initial values", ^{
        its(@"minimumValue should be zero", ^{
            [[theValue([slider minimumValue]) should] beZero];
        }); 
    });
});
```
