### PR TITLE
[v2.2.1] Silence deprecation warning for /usr/bin/atos.

### DIFF
--- a/Classes/Core/KWExample.m
+++ b/Classes/Core/KWExample.m
@@ -270,7 +270,8 @@ KWCallSite *callSiteAtAddressIfNecessary(long address){
 }
 
 KWCallSite *callSiteWithAddress(long address){
-    NSArray *args =@[@"-p", @(getpid()).stringValue, [NSString stringWithFormat:@"%lx", address]];
+    NSArray *args = @[@"-d",
+                      @"-p", @(getpid()).stringValue, [NSString stringWithFormat:@"%lx", address]];
     NSString *callSite = [NSString stringWithShellCommand:@"/usr/bin/atos" arguments:args];
 
     NSString *pattern = @".+\\((.+):([0-9]+)\\)";


### PR DESCRIPTION
### Commit Message

`callSiteWithAddress` uses the `atos` command line tool
tool, which outputs the following to stderr when run on OS X 10.9
(13A569) & XCode 5 GM:

```
--
Warning: /usr/bin/atos is moving and will be removed from a future OS X release.
It is now available in the Xcode developer tools to be invoked via: `xcrun atos`
To silence this warning, pass the '-d' command-line flag to this tool.
--
```

This commit silences the warnings.

---
### Background

When running `KiwiTests` the warning is displayed 5 times, presumably once for each of the functional tests. Unfortunately, attempts to have `callSiteWithAddress` use  `/usr/bin/xcrun atos` were unsuccessful. The following code, for example, failed to symbolicate and ended up returning the address itself:

``` diff
 KWCallSite *callSiteWithAddress(long address){
-    NSArray *args =@[@"-p", @(getpid()).stringValue, [NSString stringWithFormat:@"%lx", address]];
+    NSArray *args = @[@"atos",
+                      @"-p", @(getpid()).stringValue, [NSString stringWithFormat:@"%lx", address]];
-    NSString *callSite = [NSString stringWithShellCommand:@"/usr/bin/atos" arguments:args];
+    NSString *callSite = [NSString stringWithShellCommand:@"/usr/bin/xcrun" arguments:args];
+    NSLog(@"callSite: %@", callSite);

     NSString *pattern = @".+\\((.+):([0-9]+)\\)";
     NSError *e;
```

One example of a result of the `NSLog` statement above would be:

```
2013-09-12 10:31:24.356 otest[5382:303] callSite: 2c48217
```

In order to find out what was going on, I ran `/usr/bin/xcrun atos -v`, like so:

``` diff
 KWCallSite *callSiteWithAddress(long address){
-    NSArray *args =@[@"-p", @(getpid()).stringValue, [NSString stringWithFormat:@"%lx", address]];
+    NSArray *args = @[@"atos",
+                      @"-v",
+                      @"-p", @(getpid()).stringValue, [NSString stringWithFormat:@"%lx", address]];
-    NSString *callSite = [NSString stringWithShellCommand:@"/usr/bin/atos" arguments:args];
+    NSString *callSite = [NSString stringWithShellCommand:@"/usr/bin/xcrun" arguments:args];
+    NSLog(@"callSite: %@", callSite);

     NSString *pattern = @".+\\((.+):([0-9]+)\\)";
     NSError *e;
```

Doing so revealed the following output:

```
2013-09-12 10:41:15.827 otest[6091:303] callSite: Attached to process 6091...
looking up 0x2b49e30...
invalid section
2b49e30
```

In other words, it appears the address is deemed invalid when using `/usr/bin/xcrun atos`, but is valid when using `/usr/bin/atos`. I'm not sure why this is, but for the time being it might be a good idea to silence the warning and track the root cause of the warning as a separate issue.
