### PR TITLE
Update version to 2.2.2 for XCTest support.

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'Kiwi'
-  s.version         = '2.2.1'
+  s.version         = '2.2.2'
   s.summary         = 'A Behavior Driven Development library for iOS and OS X.'
   s.homepage        = 'https://github.com/allending/Kiwi'
   s.authors         = { 'Allen Ding' => 'alding@gmail.com', 'Luke Redpath' => 'luke@lukeredpath.co.uk', 'Marin Usalj' => 'mneorr@gmail.com', 'Stepan Hruda' => 'stepan.hruda@gmail.com' }


### PR DESCRIPTION
Changelog:
- Add class name to failure message in equality checks. (5061ae2ead443a783c99c323bb2a4991b8414053)
- Fix ARM compilation errors. (d47434b13e8b32a82de35884b1dee0a09c1f046f)
- Silence `atos` deprecation warnings output when example groups were built. (f5aec48ac16e370082e0e18a842a07e9118bba1f)
- Add "Kiwi/XCTest" subspec for XCTest unit test bundle support. (672bd210f0227ba92fb7b895dcdf6600ec126089)

---

A core member is going to need to tag `head` as `2.2.2`. I can update the CocoaPods spec once that's done, or the same person could do it/submit a pull request to https://github.com/CocoaPods/Specs.
