### PR TITLE
Change Kiwi Xcode file template to use the name of the class you are tes...

### DIFF
--- a/Xcode Templates/Kiwi Spec.xctemplate/TemplateInfo.plist
+++ b/Xcode Templates/Kiwi Spec.xctemplate/TemplateInfo.plist
@@ -20,6 +20,33 @@
     <string>___FILEBASENAME___.m</string>
 	<key>SortOrder</key>
 	<integer>1</integer>
+	<key>Options</key>
+	<array>
+		<dict>
+			<key>Default</key>
+			<string></string>
+			<key>Description</key>
+			<string>What would you like to test?</string>
+			<key>Identifier</key>
+			<string>testedClass</string>
+			<key>Name</key>
+			<string>Spec for</string>
+			<key>Required</key>
+			<true/>
+			<key>NotPersisted</key>
+			<true/>
+			<key>Type</key>
+			<string>text</string>
+		</dict>
+		<dict>
+			<key>Default</key>
+			<string>___VARIABLE_testedClass:identifier___Spec</string>
+			<key>Identifier</key>
+			<string>productName</string>
+			<key>Type</key>
+			<string>static</string>
+		</dict>
+	</array>
 	<key>Summary</key>
 	<string>Spec class of Kiwi BDD framework</string>
 </dict>

--- a/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
+++ b/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
@@ -8,6 +8,12 @@
 
 #import <Kiwi/Kiwi.h>
 
+#import "___VARIABLE_testedClass:identifier___.h"
+
 SPEC_BEGIN(___FILEBASENAMEASIDENTIFIER___)
+
+describe(@"___VARIABLE_testedClass:identifier___", ^{
+
+});
 
 SPEC_END


### PR DESCRIPTION
Hi there,

New to the Kiwi framework, but am absolutely loving it! I made a slight change to the Kiwi file template to, hopefully, make it faster for people to generate new spec files. Xcode will now ask you for the name of your class/file you are going to test and then generates the spec file using that information.

I wasn't sure if you wanted to keep it more generic, but if so, maybe this update is a second Kiwi template?
