### PR TITLE
Having methodSignatureForSelector ask the mockedObject also.

### DIFF
--- a/Classes/Mocking/KWMock.m
+++ b/Classes/Mocking/KWMock.m
@@ -401,7 +401,13 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
-    NSMethodSignature *methodSignature = [self.mockedClass instanceMethodSignatureForSelector:aSelector];
+    NSMethodSignature *methodSignature = nil;
+    
+    if (self.isPartialMock)
+            methodSignature = [self.mockedObject methodSignatureForSelector:aSelector];
+    
+    if(methodSignature == nil)
+        methodSignature = [self.mockedClass instanceMethodSignatureForSelector:aSelector];
 
     if (methodSignature != nil)
         return methodSignature;


### PR DESCRIPTION
Partial mocks should also ask the mocked object for method signatures.
