### PR TITLE
Bump version to 2.2.3

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'Kiwi'
-  s.version         = '2.2.2'
+  s.version         = '2.2.3'
   s.summary         = 'A Behavior Driven Development library for iOS and OS X.'
   s.homepage        = 'https://github.com/allending/Kiwi'
   s.authors         = { 'Allen Ding' => 'alding@gmail.com', 'Luke Redpath' => 'luke@lukeredpath.co.uk', 'Marin Usalj' => 'mneorr@gmail.com', 'Stepan Hruda' => 'stepan.hruda@gmail.com' }


### PR DESCRIPTION
Major fixes to KWCaptureSpy and other methods went in for 2.2.2 and I think upping the version is appropriate. Need to tag the release as 2.2.3 before merging this in.
