### PR TITLE
Added a flag to prevent KWCaptureSpy from raising an error when the argument is nil.

### DIFF
--- a/Classes/Core/KWCaptureSpy.h
+++ b/Classes/Core/KWCaptureSpy.h
@@ -3,6 +3,7 @@
 @interface KWCaptureSpy : NSObject<KWMessageSpying>
 
 @property (nonatomic, strong, readonly) id argument;
+@property (nonatomic, readonly, getter=isCaptured) BOOL captured;
 
 - (id)initWithArgumentIndex:(NSUInteger)index;
 

--- a/Classes/Core/KWCaptureSpy.m
+++ b/Classes/Core/KWCaptureSpy.m
@@ -9,6 +9,7 @@
 @interface KWCaptureSpy()
 
 @property (nonatomic, strong) id argument;
+@property (nonatomic, readwrite, getter=isCaptured) BOOL captured;
 
 @end
 
@@ -25,7 +26,7 @@
 }
 
 - (id)argument {
-    if (!_argument) {
+    if (!_captured) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Argument requested has yet to be captured." userInfo:nil];
     }
 
@@ -58,6 +59,8 @@
             NSData *data = [anInvocation messageArgumentDataAtIndex:_argumentIndex];
             _argument = [KWValue valueWithBytes:[data bytes] objCType:objCType];
         }
+        
+        _captured = YES;
     }
 }
 

--- a/Tests/KWCaptureTest.m
+++ b/Tests/KWCaptureTest.m
@@ -92,6 +92,17 @@
     STAssertThrows([spy argument], @"Should have raised an exception");
 }
 
+- (void)testShouldTellWhetherAnArgumentIsCaptured {
+    id robotMock = [KWMock nullMockForClass:[Robot class]];
+    KWCaptureSpy *spy = [robotMock captureArgument:@selector(speak:afterDelay:whenDone:) atIndex:1];
+    
+    STAssertEquals([spy isCaptured], NO, @"Captured flag should be 'NO'");
+    [robotMock speak:@"Hello" afterDelay:2 whenDone:^{}];
+
+    STAssertEquals([spy isCaptured], YES, @"isCaptured flag should be 'YES'");
+    STAssertNotNil(spy.argument, @"Captured argument should not be nil");
+}
+
 - (void)testAddSpyConvenienceMethodOnNSObject {
 	Robot *robot = [[Robot alloc] init];
 	KWCaptureSpy *spy = [robot captureArgument:@selector(speak:) atIndex:0];


### PR DESCRIPTION
This makes it possible to use [[expectFutureValue(spy.argument) should] beNonNil] in asynchronous captures.

For example consider the following (fake) scenario, where the subject under test performs some asynchronous method which leads to the partial mock capturing a block as the argument.

```
id partialMock = ...;

KWCaptureSpy *spy = [partialMock captureArgument:@selector(someMethodWithArg:feedback:) atIndex:1];
[[partialMock should] receive:@selector(someMethodWithArg:feedback:) andReturn:nil];

sut = [[SubjectUnderTest alloc] initWithDependency:partialMock];

__block BOOL success = NO;
[sut performAsynchronousMethodWithFeedback:^{
    success = YES;
}];

[[expectFutureValue(theValue(NO)) shouldEventuallyBeforeTimingOutAfter(3)] beNo];
[[spy.argument should] beNonNil];

void (^feedback)() = spy.argument;
feedback();

[[theValue(success) should] beYes];
```

_Please note that in this example, there's no real reason to use spying, the success value could have been subject of an expectFutureValue assertion. However the real scenario that inspired this fake one used spying to modify the arguments of the block being called at the end._

As you see, there's a bogus timeout assertion in the middle, to pause the test and allow for spy.argument to become something other than nil. If that shouldEventuallyBeforeTimingOutAfter(3) assertion weren't there, the test would fail immediately because KWCaptureSpy raises an exception when the argument is being accessed before the capturing actually happened.

```
[FAILED], NSInternalInconsistencyException "Argument requested has yet to be captured." raised
```

With the modification suggested in this pull request, you can explicitly tell KWCaptureSpy to _not_ raise an error when polling for argument, because you know you will be accessing it too early. This makes it possible to rewrite your spec to be just a little bit more obvious:

```
id partialMock = ...;

KWCaptureSpy *spy = [partialMock captureArgument:@selector(someMethodWithArg:feedback:) atIndex:1];
spy.raiseYetToBeCapturedException = NO;
[[partialMock should] receive:@selector(someMethodWithArg:feedback:) andReturn:nil];

sut = [[SubjectUnderTest alloc] initWithDependency:partialMock];

__block BOOL success = NO;
[sut performAsynchronousMethodWithFeedback:^{
    success = YES;
}];

[[expectFutureValue(spy.argument) shouldEventuallyBeforeTimingOutAfter(3)] beNonNil];

void (^feedback)() = spy.argument;
feedback();

[[theValue(success) should] beYes];
```

I've added a test for the not-raising-an-exception part, but there's no test that shows what the `raiseYetToBeCapturedException` flag can be used for in combination with future values. Cheers.
