### PR TITLE
Fix build errors when compiling `let` under ARC

### DIFF
--- a/Classes/Core/KWExample.h
+++ b/Classes/Core/KWExample.h
@@ -5,6 +5,7 @@
 //
 
 #import "KiwiConfiguration.h"
+#import "KWLet.h"
 #import "KWBlock.h"
 #import "KWVerifying.h"
 #import "KWExpectationType.h"
@@ -137,7 +138,7 @@ void pendingWithCallSite(KWCallSite *aCallSite, NSString *aDescription, void (^b
 void let(id name, id (^block)(void)); // coax Xcode into autocompleting
 #define let(var, args...) \
     __block id var = nil; \
-    let_(Block_copy(^{ __autoreleasing id *ref = &var; return ref; })(), #var, ## args)
+    let_(KW_LET_REF(var), #var, ## args)
 
 #define PRAGMA(x) _Pragma (#x)
 #define PENDING(x) PRAGMA(message ( "Pending: " #x ))

--- a/Classes/Core/KWLet.h
+++ b/Classes/Core/KWLet.h
@@ -1,0 +1,15 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2010 Allen Ding. All rights reserved.
+//
+
+#if __has_feature(objc_arr)
+#   define KW_ARC_AUTORELEASE(obj) obj
+#else
+#   define KW_ARC_AUTORELEASE(obj) [obj autorelease]
+#endif
+
+#define KW_LET_REF(var) \
+    (__autoreleasing id *) \
+    ( (void *(^)(void)) KW_ARC_AUTORELEASE([^{ void *ref = &var; return ref; } copy]) )()

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -1022,6 +1022,7 @@
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		37828762177F860B00BCD40F /* Kiwi-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Kiwi-Prefix.pch"; sourceTree = "<group>"; };
 		492F3A7916D5F7DC008E3C49 /* KWFailureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWFailureTest.m; sourceTree = "<group>"; };
+		4A03096618448E800086F533 /* KWLet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KWLet.h; sourceTree = "<group>"; };
 		4A0941AB17E7A6A800FD0EB7 /* KWLetNodeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWLetNodeTest.m; sourceTree = "<group>"; };
 		4A71047E17CC016600A7B718 /* KWLetNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWLetNode.h; sourceTree = "<group>"; };
 		4A71047F17CC016600A7B718 /* KWLetNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWLetNode.m; sourceTree = "<group>"; };
@@ -1450,6 +1451,7 @@
 				9F982C8716A802920030A0B1 /* KWFutureObject.m */,
 				9F982C9516A802920030A0B1 /* KWInvocationCapturer.h */,
 				9F982C9616A802920030A0B1 /* KWInvocationCapturer.m */,
+				4A03096618448E800086F533 /* KWLet.h */,
 				9F982CA416A802920030A0B1 /* KWMessageSpying.h */,
 				9F982CA516A802920030A0B1 /* KWMessageTracker.h */,
 				9F982CA616A802920030A0B1 /* KWMessageTracker.m */,


### PR DESCRIPTION
Created a `KW_LET_REF` macro to abstract the complexity of getting
pointer to a `__block` variable on the heap. It works like so:

``` objc
(__autoreleasing id *)      /* (5) cast result as `id *` */
(
  (void *(^)(void))         /* (3) cast back to a block */
  KW_ARC_AUTORELEASE(       /* (2) if not ARC, autorelease the block */
    [^{
      void *ref = &var; return ref;
    } copy]                 /* (1) block returns a pointer to a copied block object */
  )
)()                         /* (4) invoke the block immediately */
```

This resolves two issues that occurred under ARC:
- Using `__autoreleasing id *` to capture a reference to a `__block id`
  variable gave this error:
  
  ```
  initializing '__autoreleasing id *' with an expression of type '__strong id *' changes retain/release properties of pointer
  ```
  
  Changing to `__strong id *` yielded this:
  
  ```
  passing address of non-local object to __autoreleasing parameter for write-back
  ```
  
  Using `void *` opts us out of reference counting, resolving the errors.
- Switching to `copy` instead of `Block_copy` caused the static analyser
  to reveal an issue where the block is never released when compiled
  without ARC. Added the `KW_ARC_AUTORELEASE` macro that wraps the block
  in a call to `autorelease` when ARC is not present.
