### PR TITLE
Show warning when compiling in 64 bit mode

### DIFF
--- a/Classes/Core/Kiwi.h
+++ b/Classes/Core/Kiwi.h
@@ -12,6 +12,10 @@
 extern "C" {
 #endif
 
+#if __LP64__
+#warning "Kiwi does not support 64 bit architectures yet"
+#endif
+
 #import "KWAfterAllNode.h"
 #import "KWAfterEachNode.h"
 #import "KWAny.h"


### PR DESCRIPTION
It took me quite some time to discover that #370 is not yet implemented. To prevent others to loose valuable time, I have included a warning. 
