### PR TITLE
Added the KWLet header to the appropriate copy build phases.

### DIFF
--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -138,6 +138,11 @@
 		511901A616A95CDE006E7359 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 511901A316A95CDE006E7359 /* KWChangeMatcher.h */; };
 		511901A716A95CDE006E7359 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 511901A416A95CDE006E7359 /* KWChangeMatcher.m */; settings = {COMPILER_FLAGS = ""; }; };
 		511901A816A95CDE006E7359 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 511901A416A95CDE006E7359 /* KWChangeMatcher.m */; };
+		88E0EC551852D27F008E998A /* KWLet.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
+		88E0EC561852D280008E998A /* KWLet.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
+		88E0EC571852D281008E998A /* KWLet.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
+		88E0EC581852D514008E998A /* KWLet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
+		88E0EC591852D533008E998A /* KWLet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
 		89861D9416FE0EE5008CE99D /* KWFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89861D9316FE0EE5008CE99D /* KWFormatterTest.m */; };
 		89F9CB7C16B1C2C400E87D34 /* KWFunctionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F9CB7B16B1C2C400E87D34 /* KWFunctionalTests.m */; };
 		9F820DB816BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F820DB616BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h */; };
@@ -819,6 +824,7 @@
 			dstPath = "${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				88E0EC591852D533008E998A /* KWLet.h in CopyFiles */,
 				44FC0E6716B6377D0050D616 /* Kiwi.h in CopyFiles */,
 				44FC0E6816B6377D0050D616 /* KiwiBlockMacros.h in CopyFiles */,
 				44FC0E6916B6377D0050D616 /* KiwiConfiguration.h in CopyFiles */,
@@ -921,6 +927,7 @@
 			dstPath = "${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				88E0EC581852D514008E998A /* KWLet.h in CopyFiles */,
 				DA084E1217E3838100592D5A /* Kiwi.h in CopyFiles */,
 				DA084E1317E3838100592D5A /* KiwiBlockMacros.h in CopyFiles */,
 				DA084E1417E3838100592D5A /* KiwiConfiguration.h in CopyFiles */,
@@ -1853,6 +1860,7 @@
 				9F982D8F16A802920030A0B1 /* KWInequalityMatcher.h in Headers */,
 				9F982D9316A802920030A0B1 /* KWIntercept.h in Headers */,
 				9F982D9716A802920030A0B1 /* KWInvocationCapturer.h in Headers */,
+				88E0EC561852D280008E998A /* KWLet.h in Headers */,
 				9F982D9B16A802920030A0B1 /* KWItNode.h in Headers */,
 				9F982D9F16A802920030A0B1 /* KWMatcher.h in Headers */,
 				9F982DA316A802920030A0B1 /* KWMatcherFactory.h in Headers */,
@@ -1953,6 +1961,7 @@
 				DA084D8E17E3838100592D5A /* KWInequalityMatcher.h in Headers */,
 				DA084D8F17E3838100592D5A /* KWIntercept.h in Headers */,
 				DA084D9017E3838100592D5A /* KWInvocationCapturer.h in Headers */,
+				88E0EC551852D27F008E998A /* KWLet.h in Headers */,
 				DA084D9117E3838100592D5A /* KWItNode.h in Headers */,
 				DA084D9217E3838100592D5A /* KWMatcher.h in Headers */,
 				DA084D9317E3838100592D5A /* KWMatcherFactory.h in Headers */,
@@ -2007,6 +2016,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F982CE016A802920030A0B1 /* Kiwi.h in Headers */,
+				88E0EC571852D281008E998A /* KWLet.h in Headers */,
 				9F982CE216A802920030A0B1 /* KiwiBlockMacros.h in Headers */,
 				9F982CE416A802920030A0B1 /* KiwiConfiguration.h in Headers */,
 				9F982CE616A802920030A0B1 /* KiwiMacros.h in Headers */,


### PR DESCRIPTION
I compiled the Kiwi-iOS target to include the framework in my project and `KWLet.h` was missing from the headers directory.

I based my assumptions on what build phases to include it in based on `KWBlock.h`.

KWLet.h is included in Copy Headers and Copy Files build phases of the iOS targets, and the Copy Headers of the OSX target.
