### PR TITLE
Changed NSObject categories to protocols conformed by the categories

### DIFF
--- a/Classes/Core/NSObject+KiwiSpyAdditions.h
+++ b/Classes/Core/NSObject+KiwiSpyAdditions.h
@@ -8,7 +8,13 @@
 
 @class KWCaptureSpy;
 
-@interface NSObject (KiwiSpyAdditions)
+@protocol KiwiSpyAdditions <NSObject>
+
 - (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
 + (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
+
+@end
+
+@interface NSObject (KiwiSpyAdditions) <KiwiSpyAdditions>
+
 @end

--- a/Classes/Mocking/NSObject+KiwiMockAdditions.h
+++ b/Classes/Mocking/NSObject+KiwiMockAdditions.h
@@ -6,7 +6,7 @@
 
 #import "KiwiConfiguration.h"
 
-@interface NSObject(KiwiMockAdditions)
+@protocol KiwiMockAdditions <NSObject>
 
 #pragma mark - Creating Mocks
 
@@ -15,5 +15,9 @@
 
 + (id)nullMock;
 + (id)nullMockWithName:(NSString *)aName;
+
+@end
+
+@interface NSObject(KiwiMockAdditions) <KiwiMockAdditions>
 
 @end

--- a/Classes/Stubbing/NSObject+KiwiStubAdditions.h
+++ b/Classes/Stubbing/NSObject+KiwiStubAdditions.h
@@ -11,7 +11,7 @@
 
 @protocol KWMessageSpying;
 
-@interface NSObject(KiwiStubAdditions)
+@protocol KiwiStubAdditions <NSObject>
 
 #pragma mark - Stubbing Methods
 
@@ -51,5 +51,9 @@
 + (void)addMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern;
 + (void)removeMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern;
 + (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
+
+@end
+
+@interface NSObject(KiwiStubAdditions) <KiwiStubAdditions>
 
 @end


### PR DESCRIPTION
This allows mocked protocols to also autocomplete these methods by declaring them with type `id<YourProtocol, KiwiStubAdditions>`.
