### PR TITLE
Allow multiple `registerMatchers` in one context.

### DIFF
--- a/Classes/Core/KWExample.h
+++ b/Classes/Core/KWExample.h
@@ -17,8 +17,6 @@
 @class KWCallSite;
 @class KWExampleSuite;
 @class KWContextNode;
-@class KWSpec;
-@class KWMatcherFactory;
 
 @interface KWExample : NSObject <KWExampleNodeVisitor, KWReporting>
 

--- a/Classes/Core/KWMatcherFactory.h
+++ b/Classes/Core/KWMatcherFactory.h
@@ -26,10 +26,6 @@
 - (void)registerMatcherClass:(Class)aClass;
 - (void)registerMatcherClassesWithNamespacePrefix:(NSString *)aNamespacePrefix;
 
-#pragma mark - Registering User Defined Matchers
-
-//- (void)registerUserDefinedMatcherWithBuilder:(KWUserDefinedMatcherBuilder *)aBuilder;
-
 #pragma mark - Getting Method Signatures
 
 - (NSMethodSignature *)methodSignatureForMatcherSelector:(SEL)aSelector;

--- a/Classes/Core/KWMatcherFactory.m
+++ b/Classes/Core/KWMatcherFactory.m
@@ -90,13 +90,6 @@
     }
 }
 
-#pragma mark - Registering User Defined Matchers
-
-//- (void)registerUserDefinedMatcherWithBuilder:(KWUserDefinedMatcherBuilder *)aBuilder
-//{
-//
-//}
-
 #pragma mark - Getting Method Signatures
 
 - (NSMethodSignature *)methodSignatureForMatcherSelector:(SEL)aSelector {

--- a/Classes/Core/KWMatchers.h
+++ b/Classes/Core/KWMatchers.h
@@ -10,7 +10,7 @@
 
 @class KWUserDefinedMatcherBuilder;
 
-typedef void (^KWMatchersBuildingBlock)(KWUserDefinedMatcherBuilder *);
+typedef void (^KWMatchersBuildingBlock)(KWUserDefinedMatcherBuilder *matcherBuilder);
 
 @class KWUserDefinedMatcher;
 

--- a/Classes/Nodes/KWContextNode.h
+++ b/Classes/Nodes/KWContextNode.h
@@ -36,12 +36,12 @@
 
 #pragma mark - Managing Nodes
 
-@property (nonatomic, strong) KWRegisterMatchersNode *registerMatchersNode;
 @property (nonatomic, strong) KWBeforeAllNode *beforeAllNode;
 @property (nonatomic, strong) KWAfterAllNode *afterAllNode;
 @property (nonatomic, strong) KWBeforeEachNode *beforeEachNode;
 @property (nonatomic, strong) KWAfterEachNode *afterEachNode;
 @property (nonatomic, readonly) NSArray *nodes;
+@property (nonatomic, readonly) NSArray *registerMatchersNodes;
 @property (nonatomic, readonly) NSArray *letNodes;
 
 @property (nonatomic, readonly) KWContextNode *parentContext;
@@ -50,6 +50,7 @@
 
 - (void)addContextNode:(KWContextNode *)aNode;
 - (void)addLetNode:(KWLetNode *)aNode;
+- (void)addRegisterMatchersNode:(KWRegisterMatchersNode *)aNode;
 - (void)addItNode:(KWItNode *)aNode;
 - (void)addPendingNode:(KWPendingNode *)aNode;
 

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -778,6 +778,7 @@
 		DA084E6C17E3838100592D5A /* KWRegularExpressionPatternMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4E3C5DB01716C34900835B62 /* KWRegularExpressionPatternMatcher.h */; };
 		DA084E6D17E3838100592D5A /* KWSymbolicator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = C533F7D117462CAA000CAB02 /* KWSymbolicator.h */; };
 		DA084E6E17E3838100592D5A /* NSProxy+KiwiVerifierAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F820DB616BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h */; };
+		DA3EAD0A18A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DA3EAD0918A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m */; };
 		DA92B2A617E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DA92B2A417E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.h */; };
 		DA92B2A717E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA92B2A517E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.m */; };
 		DAA35A2317E3CF6600C41AE2 /* libKiwi-XCTest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA084E7317E3838100592D5A /* libKiwi-XCTest.a */; };
@@ -1273,6 +1274,7 @@
 		DA084D5317E381C700592D5A /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		DA084D5A17E3831E00592D5A /* KWXCFunctionalTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWXCFunctionalTest.m; sourceTree = "<group>"; };
 		DA084E7317E3838100592D5A /* libKiwi-XCTest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libKiwi-XCTest.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA3EAD0918A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWUserDefinedMatcherFunctionalTest.m; sourceTree = "<group>"; };
 		DA92B2A417E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SenTestSuite+KiwiAdditions.h"; sourceTree = "<group>"; };
 		DA92B2A517E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SenTestSuite+KiwiAdditions.m"; sourceTree = "<group>"; };
 		DAAC61CA17E75B50000165F6 /* KWObjCUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWObjCUtilitiesTest.m; sourceTree = "<group>"; };
@@ -1810,6 +1812,7 @@
 				4E3C5DB71716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m */,
 				F553B6641175D48C004FCA2E /* KWRespondToSelectorMatcherTest.m */,
 				A385CAE713AA7EA200DCA951 /* KWUserDefinedMatcherTest.m */,
+				DA3EAD0918A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m */,
 			);
 			name = Matchers;
 			sourceTree = "<group>";
@@ -2636,6 +2639,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F53B5E43115B33FC0022BC0B /* KWContainMatcherTest.m in Sources */,
+				DA3EAD0A18A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m in Sources */,
 				F53B5E66115B36EB0022BC0B /* KWEqualMatcherTest.m in Sources */,
 				F53B5EC6115B3D180022BC0B /* KWRaiseMatcherTest.m in Sources */,
 				F5C36E93115C9F0700425FDA /* KWReceiveMatcherTest.m in Sources */,

--- a/Tests/KWContextNodeTest.m
+++ b/Tests/KWContextNodeTest.m
@@ -33,6 +33,25 @@
     STAssertThrows([node setAfterEachNode:[KWAfterEachNode afterEachNodeWithCallSite:nil block:block]], @"expected exception");
 }
 
+#pragma mark - Context registerMatchers nodes
+
+- (void)testItAddsNewRegisterMatchersNodesToAnArray {
+    KWRegisterMatchersNode *nodeAbc = [[KWRegisterMatchersNode alloc] initWithCallSite:nil
+                                                                       namespacePrefix:@"ABC"];
+    KWRegisterMatchersNode *nodeXyz = [[KWRegisterMatchersNode alloc] initWithCallSite:nil
+                                                                       namespacePrefix:@"XYZ"];
+    KWContextNode *context = [KWContextNode contextNodeWithCallSite:nil
+                                                      parentContext:nil
+                                                        description:nil];
+    [context addRegisterMatchersNode:nodeAbc];
+    [context addRegisterMatchersNode:nodeXyz];
+
+    NSArray *expectedRegisterMatchersNodes = @[nodeAbc, nodeXyz];
+    STAssertEqualObjects(context.registerMatchersNodes,
+                         expectedRegisterMatchersNodes,
+                         @"register matchers nodes not stored in the order they were added");
+}
+
 #pragma mark - Context let nodes
 
 - (void)testItAddsNewLetNodesToAnArray {

--- a/Tests/KWUserDefinedMatcherFunctionalTest.m
+++ b/Tests/KWUserDefinedMatcherFunctionalTest.m
@@ -1,0 +1,71 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import "Kiwi.h"
+#import "Cruiser.h"
+
+#pragma mark - Custom Matcher Implementations
+
+@interface HALTHyperdriveLevelMatcher : KWMatcher
+@property (nonatomic, assign) NSInteger hyperdriveFuelLevel;
+@end
+
+@implementation HALTHyperdriveLevelMatcher
+
++ (NSArray *)matcherStrings {
+    return @[@"haveHyperdriveFuelLevelGreaterThan:"];
+}
+
+- (BOOL)evaluate {
+    return ((Cruiser *)self.subject).hyperdriveFuelLevel > self.hyperdriveFuelLevel;
+}
+
+- (void)haveHyperdriveFuelLevelGreaterThan:(NSInteger)hyperdriveFuelLevel {
+    self.hyperdriveFuelLevel = hyperdriveFuelLevel;
+}
+
+@end
+
+@interface FLOWCrewComplementMatcher : KWMatcher
+@property (nonatomic, assign) NSInteger crewComplement;
+@end
+
+@implementation FLOWCrewComplementMatcher
+
++ (NSArray *)matcherStrings {
+    return @[@"haveCrewComplementLessThan:"];
+}
+
+- (BOOL)evaluate {
+    return ((Cruiser *)self.subject).crewComplement < self.crewComplement;
+}
+
+- (void)haveCrewComplementLessThan:(NSInteger)crewComplement {
+    self.crewComplement = crewComplement;
+}
+
+@end
+
+#pragma mark - Tests
+
+SPEC_BEGIN(KWUserDefinedMatcherFunctionalTest)
+
+registerMatchers(@"HALT");
+registerMatchers(@"FLOW");
+
+describe(@"Cruiser", ^{
+    let(cruiser, ^id{ return [Cruiser new]; });
+
+    it(@"has a hyperdrive fuel level above 50", ^{
+        [[cruiser should] haveHyperdriveFuelLevelGreaterThan:50];
+    });
+
+    it(@"has a crew complement below 5000", ^{
+        [[cruiser should] haveCrewComplementLessThan:5000];
+    });
+});
+
+SPEC_END


### PR DESCRIPTION
The old implementation appeared to mimic that of `beforeEach` and
`afterEach`--it only allowed one per context. However, there is no need
for such a restriction when registering custom matchers. This commit
allows any number of matchers to be registered in a single context.

Other changes:
- Remove obsolete forward class declarations from KWExample header.
- Delete commented out code from KWMatcherFactory.
- Consolidate duplicated code in KWExample, KWContext in internal methods.
- Add missing variable name from block typedef (only used in
  `defineMatcher` macro).

---

For additional details on the problem, see issue #423 and [the Kiwi BDD Google Group discussion](https://groups.google.com/forum/#!topic/kiwi-bdd/_Cr5vX-Cupo).
