### PR TITLE
Allow KWCaptureSpy to capture nil block arguments

### DIFF
--- a/Classes/Core/KWCaptureSpy.m
+++ b/Classes/Core/KWCaptureSpy.m
@@ -45,15 +45,13 @@
 			void* argumentBuffer = NULL;
             [anInvocation getMessageArgument:&argumentBuffer atIndex:_argumentIndex];
 			id argument = (__bridge id)argumentBuffer;
-            if (KWObjCTypeIsBlock(objCType)) {
-                _argument = [argument copy];
-            } else {
-				if(argument == nil) {
-					_argument = [KWNull null];
-				} else {
-					_argument = argument;
-				}
-            }
+            if (argument == nil) {
+            	_argument = [KWNull null];
+            } else if(KWObjCTypeIsBlock(objCType)) {
+				_argument = [argument copy];
+			} else {
+				_argument = argument;
+			}
         } else {
             NSData *data = [anInvocation messageArgumentDataAtIndex:_argumentIndex];
             _argument = [KWValue valueWithBytes:[data bytes] objCType:objCType];


### PR DESCRIPTION
When trying to capture a block argument that is `nil`, `KWCaptureSpy` throws an exception and claims that the argument was never captured.

I believe that the error is due to this method in `KWCaptureSpy.m`:

```
- (void)object:(id)anObject didReceiveInvocation:(NSInvocation *)anInvocation {
    if (!_argument) {
        NSMethodSignature *signature = [anInvocation methodSignature];
        const char *objCType = [signature messageArgumentTypeAtIndex:_argumentIndex];
        if (KWObjCTypeIsObject(objCType) || KWObjCTypeIsClass(objCType)) {
            void* argumentBuffer = NULL;
            [anInvocation getMessageArgument:&argumentBuffer atIndex:_argumentIndex];
            id argument = (__bridge id)argumentBuffer;
            if (KWObjCTypeIsBlock(objCType)) {
                _argument = [argument copy];
            } else {
                if(argument == nil) {
                    _argument = [KWNull null];
                } else {
                    _argument = argument;
                }
            }
        } else {
            NSData *data = [anInvocation messageArgumentDataAtIndex:_argumentIndex];
            _argument = [KWValue valueWithBytes:[data bytes] objCType:objCType];
        }
    }
}
```

Specifically,

```
if (KWObjCTypeIsBlock(objCType)) {
    _argument = [argument copy];
} else {
    if(argument == nil) {
        _argument = [KWNull null];
    } else {
        _argument = argument;
    }
}
```

should be...

```
if (argument == nil) {
    _argument = [KWNull null];
} else if (KWObjCTypeIsBlock(objCType)) {
    _argument = [argument copy];
} else {
    _argument = argument;
}
```

Since the internal system that `KWCaptureSpy` uses to tell whether an argument is captured or not is whether it is equal to `nil`, not setting `_argument` to `[KWNull null]` when `argument` is a block and `nil` causes it to think that the argument was never captured.
