### PR TITLE
Remove header file import

### DIFF
--- a/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
+++ b/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
@@ -7,7 +7,6 @@
 //
 
 #import <Kiwi/Kiwi.h>
-#import "___VARIABLE_testedClass:identifier___.h"
 
 
 SPEC_BEGIN(___FILEBASENAMEASIDENTIFIER___)


### PR DESCRIPTION
Header file for test class will not be created in Xcode. There was a compile error if the .h file was imported while not existing.
