### PR TITLE
Make Kiwi spec file template work with category names

### DIFF
--- a/Xcode Templates/Kiwi Spec.xctemplate/TemplateInfo.plist
+++ b/Xcode Templates/Kiwi Spec.xctemplate/TemplateInfo.plist
@@ -40,7 +40,7 @@
 		</dict>
 		<dict>
 			<key>Default</key>
-			<string>___VARIABLE_testedClass:identifier___Spec</string>
+			<string>___VARIABLE_testedClass___Spec</string>
 			<key>Identifier</key>
 			<string>productName</string>
 			<key>Type</key>

--- a/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
+++ b/Xcode Templates/Kiwi Spec.xctemplate/___FILEBASENAME___.m
@@ -7,12 +7,12 @@
 //
 
 #import <Kiwi/Kiwi.h>
-#import "___VARIABLE_testedClass:identifier___.h"
+#import "___VARIABLE_testedClass___.h"
 
 
 SPEC_BEGIN(___FILEBASENAMEASIDENTIFIER___)
 
-describe(@"___VARIABLE_testedClass:identifier___", ^{
+describe(@"___VARIABLE_testedClass___", ^{
 
 });
 


### PR DESCRIPTION
I noticed using the Kiwi spec Xcode file template that if you enter a category name for the file under test (eg. "MyObject+Extra" that it converts this to an identifier in the file template, and replaces + with _. I think this may be necessary with SenTestCase/XCTestCase subclasses, but isn't necessary for Kiwi, as long as the class specified in `SPEC_BEGIN` has been converted to a valid class name.

This might be a matter of personal preference, I'm not sure what everyone else does in this case. I usually have `MyObject+Extras.m` and `MyObject+ExtrasSpec.m`.

Removing the `:identifier` from the template info and the base template file means adding categories works as I would have expected. The underlying Kiwi class name generated from SPEC_BEGIN will still convert to `MyObject_ExtrasSpec`.

Are there other cases where converting to an identifier is necessary for the file name itself?
