### PR TITLE
Update the Kiwi-iOS target to build for x86_64 and arm64

### DIFF
--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		88E0EC571852D281008E998A /* KWLet.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
 		88E0EC581852D514008E998A /* KWLet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
 		88E0EC591852D533008E998A /* KWLet.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4A03096618448E800086F533 /* KWLet.h */; };
+		88E6740318B435EE00367E61 /* KWSuiteConfigurationBase.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4AD1307C185BFE5E003E7145 /* KWSuiteConfigurationBase.h */; };
+		88E6740518B4374100367E61 /* KWNotificationMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4B0439BF18616B170083F852 /* KWNotificationMatcher.h */; };
 		89861D9416FE0EE5008CE99D /* KWFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89861D9316FE0EE5008CE99D /* KWFormatterTest.m */; };
 		89F9CB7C16B1C2C400E87D34 /* KWFunctionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F9CB7B16B1C2C400E87D34 /* KWFunctionalTests.m */; };
 		9F820DB816BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F820DB616BB6748003A1BA5 /* NSProxy+KiwiVerifierAdditions.h */; };
@@ -843,6 +845,8 @@
 			dstPath = "${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				88E6740518B4374100367E61 /* KWNotificationMatcher.h in CopyFiles */,
+				88E6740318B435EE00367E61 /* KWSuiteConfigurationBase.h in CopyFiles */,
 				88E0EC591852D533008E998A /* KWLet.h in CopyFiles */,
 				44FC0E6716B6377D0050D616 /* Kiwi.h in CopyFiles */,
 				44FC0E6816B6377D0050D616 /* KiwiBlockMacros.h in CopyFiles */,


### PR DESCRIPTION
`make install` will now build a fat library with all 5 iOS architectures, `i386`, `x86_64`, `armv7`, `armv7s` and `arm64`.

The Kiwi-iOS composite target needed to be updated to get the x86_64 target library build along side the others.

Building explicitly for the x86_64 simulator required a bit of trial and error, xcodebuild seems unable to build i386 and x86_64 at the same time, so I added step _specifically_ for x86_64.

Restricting the VALID_ARCHS, ARCHS and IPHONEOS_DEPLOYMENT_TARGET for the 64bit simulator build seemed to do the trick.

`ARCHS='x86_64' VALID_ARCHS='x86_64' IPHONEOS_DEPLOYMENT_TARGET='7.0'`

The resulting library shows support for all 5 architectures:

```
xcrun -sdk iphoneos lipo -info libKiwi.a 
Architectures in the fat file: libKiwi.a are: i386 x86_64 armv7 armv7s arm64
```

**Note** There were also two header files that had been omitted from the Copy Files phase of the build. 
