### PR TITLE
Break ternary operator into conditional.

### DIFF
--- a/SenTestingKit/SenTestSuite+KiwiAdditions.m
+++ b/SenTestingKit/SenTestSuite+KiwiAdditions.m
@@ -37,7 +37,12 @@
     IMP focusedSuite = imp_implementationWithBlock(^(id _self, Class aClass){
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        return ([[KWExampleSuiteBuilder sharedExampleSuiteBuilder] isFocused] && ![_self testSuiteClassHasFocus:aClass]) ? nil : (__bridge void *)[_self performSelector:newSEL withObject:aClass];
+        if ([[KWExampleSuiteBuilder sharedExampleSuiteBuilder] isFocused] &&
+            ![_self testSuiteClassHasFocus:aClass]) {
+            return nil;
+        } else {
+            return (__bridge void *)[_self performSelector:newSEL withObject:aClass];
+        }
 #pragma clang diagnostic pop
     });
     method_setImplementation(origMethod, focusedSuite);


### PR DESCRIPTION
Ternary operator much too long to read. Break into a conditional block
to improve readability.

Fixed while investigating #385.
