### PR TITLE
Use NSTimeInterval for Async Verifiers

### DIFF
--- a/Classes/Core/KWExample.h
+++ b/Classes/Core/KWExample.h
@@ -32,7 +32,7 @@
 - (id)addVerifier:(id<KWVerifying>)aVerifier;
 - (id)addExistVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite;
 - (id)addMatchVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite;
-- (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSInteger)timeout shouldWait:(BOOL)shouldWait;
+- (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSTimeInterval)timeout shouldWait:(BOOL)shouldWait;
 
 #pragma mark - Report failure
 

--- a/Classes/Core/KWExample.m
+++ b/Classes/Core/KWExample.m
@@ -96,7 +96,7 @@
     return verifier;
 }
 
-- (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSInteger)timeout shouldWait:(BOOL)shouldWait {
+- (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSTimeInterval)timeout shouldWait:(BOOL)shouldWait {
   id verifier = [KWAsyncVerifier asyncVerifierWithExpectationType:anExpectationType callSite:aCallSite matcherFactory:self.matcherFactory reporter:self probeTimeout:timeout shouldWait: shouldWait];
   [self addVerifier:verifier];
   return verifier;

--- a/Classes/Core/KWSpec.h
+++ b/Classes/Core/KWSpec.h
@@ -19,7 +19,7 @@
 + (id)addVerifier:(id<KWVerifying>)aVerifier;
 + (id)addExistVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite;
 + (id)addMatchVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite;
-+ (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSInteger)timeout shouldWait:(BOOL)shouldWait;
++ (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSTimeInterval)timeout shouldWait:(BOOL)shouldWait;
 
 #pragma mark - Building Example Groups
 

--- a/Classes/Core/KWSpec.m
+++ b/Classes/Core/KWSpec.m
@@ -149,7 +149,7 @@
     return [[[KWExampleSuiteBuilder sharedExampleSuiteBuilder] currentExample] addMatchVerifierWithExpectationType:anExpectationType callSite:aCallSite];
 }
 
-+ (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSInteger)timeout shouldWait:(BOOL)shouldWait {
++ (id)addAsyncVerifierWithExpectationType:(KWExpectationType)anExpectationType callSite:(KWCallSite *)aCallSite timeout:(NSTimeInterval)timeout shouldWait:(BOOL)shouldWait {
     return [[[KWExampleSuiteBuilder sharedExampleSuiteBuilder] currentExample] addAsyncVerifierWithExpectationType:anExpectationType callSite:aCallSite timeout:timeout shouldWait: shouldWait];
 }
 


### PR DESCRIPTION
Currently timeouts get casted to an integer, so timeouts like 0.1 will not work. Especially considering the code in KWProbePoller is built to probe every 0.1 seconds and runs on NSTimeInterval already, I think this is just a straight up bug.

The practical result of this is that test suites with lots of async work end up running for significantly longer than they need to.

It looks like it might be a regression from behavior fixed before here: https://github.com/allending/Kiwi/commit/b39fe450ba0d6f2433303e257f97259d39a167c0

I didn't see any existing tests that seemed exceptionally relevant, and I'm rather unfamiliar with the code base, so I didn't add any. Existing tests still pass.
