### PR TITLE
Run unit tests on multiple SDKs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: objective-c
 before_install:
   - gem install xcpretty
-script: make ci | xcpretty -c
+env:
+  matrix:
+    - TEST_SDK=iphonesimulator6.1
+    - TEST_SDK=iphonesimulator
+script: make ci $TEST_SDK | xcpretty -c
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TEST_SDK?="iphonesimulator"
+
 default: clean ios
 
 clean:
@@ -11,7 +13,7 @@ install:
 	xcodebuild -project Kiwi.xcodeproj -scheme Kiwi-iOS install
 
 test:
-	xcodebuild -project Kiwi.xcodeproj -scheme Kiwi -sdk iphonesimulator test
+	xcodebuild -project Kiwi.xcodeproj -scheme Kiwi -sdk $(TEST_SDK) test
 
 ci: test
 


### PR DESCRIPTION
I think it might be nice to ensure that Kiwi works for iOS SDK 6.1 (a friend of mine uses an old MacBook that can't run Mavericks, and so can't use iOS SDK 7.0). Feel free to close this PR if that seems like more trouble than it's worth, though.

---

By the way, I encountered an interesting false positive with `xcpretty` when attempting to run against `iphonesimulator5.1`: `xcpretty` exited with a `0` status code despite the fact that the `xcodebuild` command failed. You can [see the full output here](https://travis-ci.org/modocache/Kiwi/jobs/20285282). I'm not sure, but it might be related to https://github.com/supermarin/xcpretty/pull/66.
