### PR TITLE
Bump Podspec to 2.2.4

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'Kiwi'
-  s.version         = '2.2.3'
+  s.version         = '2.2.4'
   s.summary         = 'A Behavior Driven Development library for iOS and OS X.'
   s.homepage        = 'https://github.com/allending/Kiwi'
   s.authors         = { 'Allen Ding' => 'alding@gmail.com', 'Luke Redpath' => 'luke@lukeredpath.co.uk', 'Marin Usalj' => 'mneorr@gmail.com', 'Stepan Hruda' => 'stepan.hruda@gmail.com' }


### PR DESCRIPTION
Hi, I was hoping to release a more recent Podspec for Kiwi. Based on the commit history, [its been 5 months since a release](https://github.com/allending/Kiwi/commits/master/Kiwi.podspec). Since then a major [issue](https://github.com/allending/Kiwi/issues/390) for me has been fixed, so I was hoping to take advantage of that. 

I wasn't sure if there needs to be extensive testing or something done before making a release; if so you can just close this PR. 
