### PR TITLE
Reindent numbered lists in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,20 +7,20 @@ and we'd love your help!
 
 Kiwi currently uses two channels for reporting bugs:
 
-1. If Kiwi isn't working as you'd expect it to, but you're not sure whether
-   you're using it correctly, please send a message to the
-   [Kiwi Google group](https://groups.google.com/forum/#!forum/kiwi-bdd).
+ 1. If Kiwi isn't working as you'd expect it to, but you're not sure whether
+    you're using it correctly, please send a message to the
+    [Kiwi Google group](https://groups.google.com/forum/#!forum/kiwi-bdd).
 
-   Once your issue has been resolved, please consider contributing to the
-   [Wiki](https://github.com/allending/Kiwi/wiki) to help people
-   who might experience similar issues in the future.
+    Once your issue has been resolved, please consider contributing to the
+    [Wiki](https://github.com/allending/Kiwi/wiki) to help people
+    who might experience similar issues in the future.
 
-2. If you're sure that you're using Kiwi correctly, but Kiwi still does not
-   behave as you'd expect it to, you may have found a bug. If no one
-   has [already reported the issue](https://github.com/allending/Kiwi/issues?state=open),
-   please [submit a new issue](https://github.com/allending/Kiwi/issues/new),
-   and include any and all information maintainers might need to fix the problem.
-   It's not easy to fix bugs, but detailed reports help!
+ 2. If you're sure that you're using Kiwi correctly, but Kiwi still does not
+    behave as you'd expect it to, you may have found a bug. If no one
+    has [already reported the issue](https://github.com/allending/Kiwi/issues?state=open),
+    please [submit a new issue](https://github.com/allending/Kiwi/issues/new),
+    and include any and all information maintainers might need to fix the problem.
+    It's not easy to fix bugs, but detailed reports help!
 
 ## Pull Requests
 
@@ -31,4 +31,3 @@ and submit a pull request.
 Please include a description of your changes with your pull request.
 All pull requests that involve changes to the source code should include
 tests that prove the changes behave as stated in the pull request message.
-


### PR DESCRIPTION
Markdown not only requires multi-paragraph list items to be indented at the same level, but explicitly requires either 1 tab or 4 spaces ([Markdown Syntax#list](http://daringfireball.net/projects/markdown/syntax#list)).

Reindent 3 -> 4 spaces, as the 3-space indent was throwing off Marked.app (the second paragraph in the list item was being interpreted as at the top level). (I believe Marked.app uses MultiMarkdown out of the box.)
