### PR TITLE
KWSpec: Cast objc_msgSend for 64-bit device.

### DIFF
--- a/Classes/Core/KWSpec.m
+++ b/Classes/Core/KWSpec.m
@@ -122,14 +122,18 @@
 
 - (void)example:(KWExample *)example didFailWithFailure:(KWFailure *)failure {
     if ([self respondsToSelector:@selector(recordFailureWithDescription:inFile:atLine:expected:)]) {
-        objc_msgSend(self,
-                     @selector(recordFailureWithDescription:inFile:atLine:expected:),
-                     [[failure exceptionValue] description],
-                     failure.callSite.filename,
-                     failure.callSite.lineNumber,
-                     NO);
+        void (*recordFailure)(id, SEL, NSString *, NSString *, NSUInteger, BOOL) =
+            (void (*)(id, SEL, NSString *, NSString *, NSUInteger, BOOL))objc_msgSend;
+        recordFailure(self,
+                      @selector(recordFailureWithDescription:inFile:atLine:expected:),
+                      [[failure exceptionValue] description],
+                      failure.callSite.filename,
+                      failure.callSite.lineNumber,
+                      NO);
     } else {
-        objc_msgSend(self, @selector(failWithException:), [failure exceptionValue]);
+        void (*failWithException)(id, SEL, NSException *) =
+            (void (*)(id, SEL, NSException *))objc_msgSend;
+        failWithException(self, @selector(failWithException:), [failure exceptionValue]);
     }
 }
 


### PR DESCRIPTION
Fixes issue #479. See Apple's 64-bit Transition Guide for details:

https://developer.apple.com/library/ios/documentation/General/Conceptual/CocoaTouch64BitGuide/ConvertingYourAppto64-Bit/ConvertingYourAppto64-Bit.html

---

Confirmed initial bug and tested the fix on an iPhone 5s.
