### PR TITLE
Update README to use SVG for Travis Icon [ci skip]

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 # Simple BDD for iOS #
-[![Build Status](https://travis-ci.org/allending/Kiwi.png?branch=master)](https://travis-ci.org/allending/Kiwi)
+[![Build Status](https://travis-ci.org/allending/Kiwi.svg?branch=master)](https://travis-ci.org/allending/Kiwi)
 
 Kiwi is a Behavior Driven Development library for iOS development.
 The goal is to provide a BDD library that is exquisitely simple to setup and use.


### PR DESCRIPTION
If you look at the [rendered diff](https://github.com/allending/Kiwi/pull/490/files?short_path=1e290ac#diff-1e290ac8433d555bce009b162cb869d0) it looks much better.
