### PR TITLE
KWValue support for stdbool.

### DIFF
--- a/Classes/Core/KWObjCUtilities.h
+++ b/Classes/Core/KWObjCUtilities.h
@@ -14,7 +14,7 @@ BOOL KWObjCTypeIsFloatingPoint(const char *objCType);
 BOOL KWObjCTypeIsIntegral(const char *objCType);
 BOOL KWObjCTypeIsSignedIntegral(const char *objCType);
 BOOL KWObjCTypeIsUnsignedIntegral(const char *objCType);
-BOOL KWObjCTypeIsBool(const char *objCType);
+BOOL KWObjCTypeIsBoolean(const char *objCType);
 BOOL KWObjCTypeIsObject(const char *objCType);
 BOOL KWObjCTypeIsCharString(const char *objCType);
 BOOL KWObjCTypeIsClass(const char *objCType);

--- a/Classes/Core/KWObjCUtilities.m
+++ b/Classes/Core/KWObjCUtilities.m
@@ -41,8 +41,8 @@ BOOL KWObjCTypeIsUnsignedIntegral(const char *objCType) {
            strcmp(objCType, @encode(unsigned long long)) == 0;
 }
 
-BOOL KWObjCTypeIsBool(const char *objCType) {
-    return strcmp(objCType, @encode(BOOL)) == 0;
+BOOL KWObjCTypeIsBoolean(const char *objCType) {
+    return strcmp(objCType, @encode(BOOL)) == 0 || strcmp(objCType, @encode(bool)) == 0;
 }
 
 BOOL KWObjCTypeIsObject(const char *objCType) {

--- a/Classes/Core/KWValue.m
+++ b/Classes/Core/KWValue.m
@@ -108,7 +108,7 @@
 #pragma mark - Accessing Numeric Values
 
 - (NSNumber *)numberValue {
-    if (!KWObjCTypeIsNumeric(self.objCType) && !KWObjCTypeIsBool(self.objCType)) {
+    if (!KWObjCTypeIsNumeric(self.objCType) && !KWObjCTypeIsBoolean(self.objCType)) {
         [NSException raise:NSInternalInconsistencyException
                     format:@"cannot return number value because wrapped value is non-numeric"];
     }

--- a/Classes/Core/NSNumber+KiwiAdditions.h
+++ b/Classes/Core/NSNumber+KiwiAdditions.h
@@ -12,6 +12,7 @@
 
 + (id)numberWithBytes:(const void *)bytes objCType:(const char *)anObjCType;
 + (id)numberWithBoolBytes:(const void *)bytes;
++ (id)numberWithStdBoolBytes:(const void *)bytes;
 + (id)numberWithCharBytes:(const void *)bytes;
 + (id)numberWithDoubleBytes:(const void *)bytes;
 + (id)numberWithFloatBytes:(const void *)bytes;

--- a/Classes/Core/NSNumber+KiwiAdditions.m
+++ b/Classes/Core/NSNumber+KiwiAdditions.m
@@ -15,6 +15,8 @@
     // Yeah, this is ugly.
     if (KWObjCTypeEqualToObjCType(anObjCType, @encode(BOOL)))
         return [self numberWithBoolBytes:bytes];
+    else if (KWObjCTypeEqualToObjCType(anObjCType, @encode(bool)))
+        return [self numberWithStdBoolBytes:bytes];
     else if (KWObjCTypeEqualToObjCType(anObjCType, @encode(char)))
         return [self numberWithCharBytes:bytes];
     else if (KWObjCTypeEqualToObjCType(anObjCType, @encode(double)))
@@ -49,6 +51,10 @@
 
 + (id)numberWithBoolBytes:(const void *)bytes {
     return @(*(const BOOL *)bytes);
+}
+
++ (id)numberWithStdBoolBytes:(const void *)bytes {
+    return @(*(const bool *)bytes);
 }
 
 + (id)numberWithCharBytes:(const void *)bytes {

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -771,6 +771,7 @@
 		DA3EAD0A18A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DA3EAD0918A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m */; };
 		DA92B2A617E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DA92B2A417E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.h */; };
 		DA92B2A717E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA92B2A517E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.m */; };
+		DA9C69F8190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C69F7190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m */; };
 		DAA1B3AF18CF25C00015CF7A /* KWNotificationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = DAA1B3AD18CF25C00015CF7A /* KWNotificationMatcher.h */; };
 		DAA1B3B018CF25C00015CF7A /* KWNotificationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA1B3AE18CF25C00015CF7A /* KWNotificationMatcher.m */; };
 		DAA1B3B118CF29770015CF7A /* KWNotificationMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DAA1B3AD18CF25C00015CF7A /* KWNotificationMatcher.h */; };
@@ -1269,6 +1270,7 @@
 		DA3EAD0918A86E5600EBBF57 /* KWUserDefinedMatcherFunctionalTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWUserDefinedMatcherFunctionalTest.m; sourceTree = "<group>"; };
 		DA92B2A417E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SenTestSuite+KiwiAdditions.h"; sourceTree = "<group>"; };
 		DA92B2A517E6A3EF0062F84D /* SenTestSuite+KiwiAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SenTestSuite+KiwiAdditions.m"; sourceTree = "<group>"; };
+		DA9C69F7190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSNumber_KiwiAdditionsTests.m; sourceTree = "<group>"; };
 		DAA1B3AD18CF25C00015CF7A /* KWNotificationMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWNotificationMatcher.h; sourceTree = "<group>"; };
 		DAA1B3AE18CF25C00015CF7A /* KWNotificationMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWNotificationMatcher.m; sourceTree = "<group>"; };
 		DAAC61CA17E75B50000165F6 /* KWObjCUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWObjCUtilitiesTest.m; sourceTree = "<group>"; };
@@ -1691,13 +1693,6 @@
 			path = "Xcode Templates/Kiwi Spec.xctemplate";
 			sourceTree = "<group>";
 		};
-		C922D1DB158045DD00995B43 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Classes;
-			sourceTree = "<group>";
-		};
 		DA084D5517E3831E00592D5A /* KiwiXCTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1731,14 +1726,13 @@
 		F5015BE211583C27002E9A98 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F5A9EFD211741E7700E9EDA3 /* Matchers */,
+				F5A1E6081174322A002223E1 /* Mocks, Stubs, and Spying */,
 				89F9CB7816B1BE0E00E87D34 /* Functional */,
 				080E96DDFE201D6D7F000001 /* Test Classes */,
 				F5A1E60711743223002223E1 /* Specs */,
 				F5BDB84711C0C8CE00DD3474 /* Example Groups */,
-				F5A9EFD211741E7700E9EDA3 /* Matchers */,
-				F5A1E6081174322A002223E1 /* Mocks, Stubs, and Spying */,
 				F5A1E612117432AC002223E1 /* Support */,
-				C922D1DB158045DD00995B43 /* Classes */,
 				F508565011BE61A1000EAD4E /* KiwiTestConfiguration.h */,
 			);
 			path = Tests;
@@ -1773,6 +1767,7 @@
 				F5FC83B511B100B100BF98A2 /* KWStringUtilitiesTest.m */,
 				F5C6FD2311782A290068BBC8 /* KWValueTest.m */,
 				89861D9316FE0EE5008CE99D /* KWFormatterTest.m */,
+				DA9C69F7190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -2658,6 +2653,7 @@
 				9F982A3916A801800030A0B1 /* Cruiser.m in Sources */,
 				9F982A3A16A801800030A0B1 /* Engine.m in Sources */,
 				9F982A3B16A801800030A0B1 /* Fighter.m in Sources */,
+				DA9C69F8190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m in Sources */,
 				9F982A3C16A801800030A0B1 /* Galaxy.m in Sources */,
 				9F982A3D16A801800030A0B1 /* KiwiAppDelegate.m in Sources */,
 				9F982A3E16A801800030A0B1 /* KiwiViewController.m in Sources */,

--- a/Tests/KWObjCUtilitiesTest.m
+++ b/Tests/KWObjCUtilitiesTest.m
@@ -17,16 +17,21 @@
 
 @implementation KWObjCUtilitiesTest
 
-#pragma mark KWObjCTypeIsBool
+#pragma mark KWObjCTypeIsBoolean
 
-- (void)testItRecognizesBoolObjCTypes {
-    STAssertTrue(KWObjCTypeIsBool(@encode(BOOL)),
-                 @"Expected BOOL type to be evaluated as a BOOL.");
+- (void)testBOOLIsABoolean {
+    STAssertTrue(KWObjCTypeIsBoolean(@encode(BOOL)),
+                 @"Expected BOOL to be evaluated as a boolean.");
 }
 
-- (void)testItRecognizesNonBoolObjCTypes {
-    STAssertFalse(KWObjCTypeIsBool(@encode(int)),
-                  @"Did not expect int type to be evaluated as a BOOL.");
+- (void)testStdBoolIsABoolean {
+    STAssertTrue(KWObjCTypeIsBoolean(@encode(bool)),
+                 @"Expected bool to be evaluated as a boolean.");
+}
+
+- (void)testIntIsNotABoolean {
+    STAssertFalse(KWObjCTypeIsBoolean(@encode(int)),
+                  @"Did not expect int type to be evaluated as a boolean.");
 }
 
 #pragma mark KWSelectorParameterCount

--- a/Tests/KWValueTest.m
+++ b/Tests/KWValueTest.m
@@ -93,10 +93,23 @@
     STAssertEquals(boolValue, (BOOL)value, @"expected value to convert wrapped value to bool");
 }
 
+- (void)testItShouldRaiseIfConvertingNonNumericToBool {
+    NSRange range = (NSRange){ .location = 1, .length = 2 };
+    KWValue *value = [KWValue valueWithBytes:&range objCType:@encode(NSRange)];
+    STAssertThrows([value boolValue], @"expected value to raise when comvertic non-numeric wrapped value to BOOL");
+}
+
+- (void)testItShouldConvertStdBoolToBoolValues {
+    bool value = true;
+    KWValue *wrappedValue = [KWValue valueWithBytes:&value objCType:@encode(bool)];
+    BOOL boolValue = [wrappedValue boolValue];
+    STAssertEquals(boolValue, (BOOL)value, @"expected value to convert stdbool value to BOOL");
+}
+
 - (void)testItShouldReturnStructDataValues {
     NSRange range;
     range.location = 0;
-    range.location = 1;
+    range.length = 1;
     KWValue *wrappedValue = [KWValue valueWithBytes:&range objCType:@encode(NSRange)];
     NSData *data = [wrappedValue dataValue];
     NSRange result = *(NSRange *)[data bytes];

--- a/Tests/NSNumber_KiwiAdditionsTests.m
+++ b/Tests/NSNumber_KiwiAdditionsTests.m
@@ -1,0 +1,33 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import "Kiwi.h"
+#import "KiwiTestConfiguration.h"
+#import "NSNumber+KiwiAdditions.h"
+
+@interface NSNumber_KiwiAdditionsTests : SenTestCase
+
+@end
+
+@implementation NSNumber_KiwiAdditionsTests
+
+#pragma mark numberWithBoolBytes
+
+- (void)testNumberWithBoolBytesReturnsANumberFromBoolBytes {
+    BOOL value = YES;
+    NSNumber *number = [NSNumber numberWithBoolBytes:&value];
+    STAssertEqualObjects(number, @1, @"Expected +numberWithBoolBytes: to convert YES to @1.");
+}
+
+#pragma mark numberWithStdBoolBytes
+
+- (void)testNumberWithStdBoolBytesReturnsANumberFromStdBoolBytes {
+    bool value = true;
+    NSNumber *number = [NSNumber numberWithStdBoolBytes:&value];
+    STAssertEqualObjects(number, @1, @"Expected +numberWithStdBoolBytes: to convert true to @1.");
+}
+
+@end


### PR DESCRIPTION
KWValue could only wrap Objective-C BOOL type, but lacked support for
stdbool. As a result, `-[KWValue boolValue]` would raise an exception
when invoked with a wrapped `bool` value.

Add support for `bool` wrapping.
- Rename `KWObjCTypeIsBool` to `KWObjCTypeIsBoolean`, and have it return
  `YES` for both `BOOL` and `bool`.
- Add `NSNumber` conversion method for `bool`.
- Add tests.

Fixes issue #506.
