### PR TITLE
fix for error: 'XCTest/XCTest.h' file not found with Xcode 6.1

### DIFF
--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -2353,6 +2353,7 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" = (
 					"$(inherited)",
@@ -2387,6 +2388,7 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" = (
 					"$(inherited)",


### PR DESCRIPTION
compile fix for Kiwi (iOS) target with latest Xcode