### PR TITLE
Fix framework search paths to avoid compilation errors.

### DIFF
--- a/Kiwi.podspec
+++ b/Kiwi.podspec
@@ -19,24 +19,16 @@ Pod::Spec.new do |s|
   # TODO: clean this up once Apple gets their stuff together
   s.ios.xcconfig = {
     "FRAMEWORK_SEARCH_PATHS" => %w[
-      $(SDKROOT)/Developer/Library/Frameworks
+      $(PLATFORM_DIR)/Developer/Library/Frameworks
       $(inherited)
       $(DEVELOPER_FRAMEWORKS_DIR)
-    ].join(' '),
-    "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" => %w[
-      $(inherited)
-      $(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/Library/Frameworks
-    ].join(' '),
-    "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator8.0]" => %w[
-      $(inherited)
-      $(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks
     ].join(' '),
   }
   s.osx.xcconfig = {
     "FRAMEWORK_SEARCH_PATHS" => "$(DEVELOPER_FRAMEWORKS_DIR)",
     "FRAMEWORK_SEARCH_PATHS[sdk=macosx10.10]" => %w[
       $(inherited)
-      $(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks
+      $(PLATFORM_DIR)/Developer/Library/Frameworks
     ].join(' '),
   }
 

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -2350,7 +2350,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.0;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
@@ -2384,7 +2384,7 @@
 				CURRENT_PROJECT_VERSION = 1.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -1749,7 +1749,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0600;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Allen Ding";
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Kiwi" */;

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-OSX.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -49,6 +49,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "832C8323157263B300F160D5"
+            BuildableName = "libKiwi-OSX.a"
+            BlueprintName = "Kiwi-OSX"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-iOS.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6BC17EC2155E3A47000B3AA4"
+            BuildableName = "Kiwi-iOS"
+            BlueprintName = "Kiwi-iOS"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -49,6 +49,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F5015B9E11583A77002E9A98"
+            BuildableName = "libKiwi.a"
+            BlueprintName = "Kiwi"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
Commit 05c14cfdf6d9ebf9b7625b31b980bdca1aa4848a used $SDKROOT
to access those framework search paths, but $SDKROOT only expands
to the SDK name, while $PLATFORM_DIR expands to the full path of
the platform (this allows removing the hardcoding of the platform
names in the podfile).

Seems that using the $PLATFORM_DIR is the accepted answer from the community (see http://stackoverflow.com/questions/24275470/xctest-xctest-h-not-found-on-old-projects-built-in-xcode-6).

Note that I haven’t tested the Cocoapods changes, but they should work.