### PR TITLE
Removed hardcoded references to iPhone OS and iOS Simulator SDKs

### DIFF
--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -2354,11 +2354,11 @@
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" = (
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/Library/Frameworks",
 				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator8.0]" = (
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks",
 				);
@@ -2388,11 +2388,11 @@
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" = (
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/Library/Frameworks",
 				);
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator8.0]" = (
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks",
 				);


### PR DESCRIPTION
The project settings had hardcoded path setup for SDK 8.0. When tried to build with newer SDK 8.1 the build failed. Updated the settings so it reference generic SDK.
