### PR TITLE
Add beNilOrEmpty to KWBeEmptyMatcher

### DIFF
--- a/Classes/Matchers/KWBeEmptyMatcher.h
+++ b/Classes/Matchers/KWBeEmptyMatcher.h
@@ -12,5 +12,6 @@
 #pragma mark - Configuring Matchers
 
 - (void)beEmpty;
+- (void)beNilOrEmpty;
 
 @end

--- a/Classes/Matchers/KWBeEmptyMatcher.m
+++ b/Classes/Matchers/KWBeEmptyMatcher.m
@@ -11,6 +11,7 @@
 
 #pragma mark - Properties
 
+@property (nonatomic, readwrite, getter=isExpectsNil) BOOL expectsNil;
 @property (nonatomic, readwrite) NSUInteger count;
 
 @end
@@ -20,13 +21,17 @@
 #pragma mark - Getting Matcher Strings
 
 + (NSArray *)matcherStrings {
-    return @[@"beEmpty"];
+    return @[@"beNilOrEmpty", @"beEmpty"];
 }
 
 #pragma mark - Matching
 
 - (BOOL)evaluate {
-    if ([self.subject respondsToSelector:@selector(count)]) {
+    if (self.expectsNil && self.subject == nil) {
+        self.count = 0;
+        return YES;
+    }
+    else if ([self.subject respondsToSelector:@selector(count)]) {
         self.count = [self.subject count];
         return self.count == 0;
     }
@@ -49,20 +54,28 @@
 }
 
 - (NSString *)failureMessageForShould {
-    return [NSString stringWithFormat:@"expected subject to be empty, got %@", [self countPhrase]];
+    return [NSString stringWithFormat:@"expected subject to %@, got %@", [self description], [self countPhrase]];
 }
 
 - (NSString *)failureMessageForShouldNot {
-    return @"expected subject not to be empty";
+    return [NSString stringWithFormat:@"expected subject not to %@", [self description]];
 }
 
 - (NSString *)description {
+    if (self.expectsNil) {
+        return @"be nil or empty";
+    }
     return @"be empty";
 }
 
 #pragma mark - Configuring Matchers
 
 - (void)beEmpty {
+    self.expectsNil = NO;
+}
+
+- (void)beNilOrEmpty {
+    self.expectsNil = YES;
 }
 
 @end

--- a/Tests/KWBeEmptyMatcherTest.m
+++ b/Tests/KWBeEmptyMatcherTest.m
@@ -18,7 +18,7 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWBeEmptyMatcher matcherStrings];
-    NSArray *expectedStrings = @[@"beEmpty"];
+    NSArray *expectedStrings = @[@"beNilOrEmpty", @"beEmpty"];
     XCTAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                           [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                           @"expected specific matcher strings");
@@ -31,6 +31,20 @@
     XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
 
+- (void)testItShouldMatchEmptyCollectionsWithNilOrEmpty {
+    id subject = @{};
+    KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:subject];
+    [matcher beNilOrEmpty];
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
+}
+
+- (void)testItShouldMatchNilCollections {
+    id subject = nil;
+    KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:subject];
+    [matcher beNilOrEmpty];
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
+}
+
 - (void)testItShouldNotMatchNonEmptyCollections {
     id subject = @{@"foo": @"bar"};
     KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:subject];
@@ -38,11 +52,25 @@
     XCTAssertFalse([matcher evaluate], @"expected negative match");
 }
 
+- (void)testItShouldNotMatchNonEmptyCollectionsWithNilOrEmpty {
+    id subject = @{@"foo": @"bar"};
+    KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:subject];
+    [matcher beNilOrEmpty];
+    XCTAssertFalse([matcher evaluate], @"expected negative match");
+}
 
 - (void)testItShouldHaveHumanReadableDescription
 {
-  KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:nil];
-  XCTAssertEqualObjects(@"be empty", [matcher description], @"description should match");
+    KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:nil];
+    [matcher beEmpty];
+    XCTAssertEqualObjects(@"be empty", [matcher description], @"description should match");
+}
+
+- (void)testItShouldHaveHumanReadableDescriptionWithNilOrEmpty
+{
+    KWBeEmptyMatcher *matcher = [KWBeEmptyMatcher matcherWithSubject:nil];
+    [matcher beNilOrEmpty];
+    XCTAssertEqualObjects(@"be nil or empty", [matcher description], @"description should match");
 }
 
 @end

--- a/Tests/KWFunctionalTests.m
+++ b/Tests/KWFunctionalTests.m
@@ -143,6 +143,7 @@ describe(@"Greeting", ^{
 
     describe(@"default subject", ^{
         specify(^{ [[subject should] beEmpty]; });
+        specify(^{ [[subject should] beNilOrEmpty]; });
     });
 
     context(@"with the subject \"world\"", ^{


### PR DESCRIPTION
A little improvement to KWBeEmptyMatcher. It may be useful in cases where you doesn't now if your collection wasn't initialized or it has no items.
Tests were updated and all passes.