### PR TITLE
xctest not found in xcode 6. adding path /Developer/Library/Frameworks

### DIFF
--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -2350,9 +2350,9 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1.0;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"<Multiple",
+					"values>",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" = (
 					"$(inherited)",
@@ -2384,9 +2384,9 @@
 				CURRENT_PROJECT_VERSION = 1.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"<Multiple",
+					"values>",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos8.0]" = (
 					"$(inherited)",


### PR DESCRIPTION
@supermarin 
While adding Kiwi as a submodule to an existing project, Kiwi was complaining of not finding XCTest.h. With Xcode 6, adding "$(PLATFORM_DIR)/Developer/Library/Frameworks" to the FRAMEWORK_SEARCH_PATHS fixes this problem.