### PR TITLE
Adds shared examples to Kiwi.

### DIFF
--- a/Classes/Core/Examples/KWSharedExample.h
+++ b/Classes/Core/Examples/KWSharedExample.h
@@ -1,0 +1,23 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef void (^KWSharedExampleBlock)(Class describedClass);
+
+@interface KWSharedExample : NSObject
+
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) KWSharedExampleBlock block;
+
+- (id)initWithName:(NSString *)name block:(KWSharedExampleBlock)block;
+
+@end
+
+#pragma mark - Building Shared Example Groups
+
+void sharedExamplesFor(NSString *name, KWSharedExampleBlock block);
+void itBehavesLike(NSString *name, Class describedClass);

--- a/Classes/Core/Examples/KWSharedExample.h
+++ b/Classes/Core/Examples/KWSharedExample.h
@@ -6,7 +6,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void (^KWSharedExampleBlock)(Class describedClass);
+typedef void (^KWSharedExampleBlock)(NSDictionary *data);
 
 @interface KWSharedExample : NSObject
 
@@ -20,4 +20,4 @@ typedef void (^KWSharedExampleBlock)(Class describedClass);
 #pragma mark - Building Shared Example Groups
 
 void sharedExamplesFor(NSString *name, KWSharedExampleBlock block);
-void itBehavesLike(NSString *name, Class describedClass);
+void itBehavesLike(NSString *name, NSDictionary *data);

--- a/Classes/Core/Examples/KWSharedExample.m
+++ b/Classes/Core/Examples/KWSharedExample.m
@@ -1,0 +1,40 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import "KWSharedExample.h"
+#import "KWSharedExampleRegistry.h"
+#import "KWExample.h"
+
+@implementation KWSharedExample
+
+#pragma mark - Initializing
+
+- (id)initWithName:(NSString *)name block:(KWSharedExampleBlock)block {
+    NSParameterAssert(name);
+    NSParameterAssert(block);
+
+    self = [super init];
+    if (self) {
+        _name = name;
+        _block = block;
+    }
+    return self;
+}
+
+@end
+
+#pragma mark - Building Example Groups
+
+void sharedExamplesFor(NSString *name, KWSharedExampleBlock block) {
+    KWSharedExample *sharedExample = [[KWSharedExample alloc] initWithName:name block:block];
+    [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:sharedExample];
+}
+
+void itBehavesLike(NSString *name, Class describedClass) {
+    KWSharedExample *sharedExample = [[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:name];
+    NSString *description = [NSString stringWithFormat:@"behaves like %@", sharedExample.name];
+    context(description, ^{ sharedExample.block(describedClass); });
+}

--- a/Classes/Core/Examples/KWSharedExample.m
+++ b/Classes/Core/Examples/KWSharedExample.m
@@ -33,8 +33,8 @@ void sharedExamplesFor(NSString *name, KWSharedExampleBlock block) {
     [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:sharedExample];
 }
 
-void itBehavesLike(NSString *name, Class describedClass) {
+void itBehavesLike(NSString *name, NSDictionary *data) {
     KWSharedExample *sharedExample = [[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:name];
     NSString *description = [NSString stringWithFormat:@"behaves like %@", sharedExample.name];
-    context(description, ^{ sharedExample.block(describedClass); });
+    context(description, ^{ sharedExample.block(data); });
 }

--- a/Classes/Core/Examples/KWSharedExampleRegistry.h
+++ b/Classes/Core/Examples/KWSharedExampleRegistry.h
@@ -1,0 +1,17 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class KWSharedExample;
+
+@interface KWSharedExampleRegistry : NSObject
+
++ (instancetype)sharedRegistry;
+- (KWSharedExample *)sharedExampleForName:(NSString *)name;
+- (void)registerSharedExample:(KWSharedExample *)sharedExample;
+
+@end

--- a/Classes/Core/Examples/KWSharedExampleRegistry.m
+++ b/Classes/Core/Examples/KWSharedExampleRegistry.m
@@ -1,0 +1,66 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import "KWSharedExampleRegistry.h"
+#import "KWSharedExample.h"
+
+@interface KWSharedExampleRegistry ()
+@property (nonatomic, strong) NSMutableDictionary *sharedExamples;
+@end
+
+@implementation KWSharedExampleRegistry
+
+#pragma mark - Initializing
+
++ (instancetype)sharedRegistry {
+    static KWSharedExampleRegistry *sharedRegistry = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedRegistry = [self new];
+
+    });
+    return sharedRegistry;
+}
+
+- (id)init {
+    self = [super init];
+    if (self) {
+        _sharedExamples = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+#pragma mark - Public Interface
+
+- (KWSharedExample *)sharedExampleForName:(NSString *)name {
+    [self raiseIfSharedExampleNotRegistered:name];
+    return [_sharedExamples objectForKey:name];
+}
+
+- (void)registerSharedExample:(KWSharedExample *)sharedExample {
+    [self raiseIfSharedExampleAlreadyRegistered:sharedExample];
+    [_sharedExamples setObject:sharedExample forKey:sharedExample.name];
+}
+
+#pragma mark - Internal Methods
+
+- (void)raiseIfSharedExampleNotRegistered:(NSString *)name {
+    if (![_sharedExamples objectForKey:name]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Kiwi shared example error: No shared example registered for '%@'",
+                           name];
+    }
+}
+
+- (void)raiseIfSharedExampleAlreadyRegistered:(KWSharedExample *)sharedExample {
+    if ([_sharedExamples objectForKey:sharedExample.name]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Kiwi shared example error: Shared example already registered for '%@'",
+                           sharedExample.name];
+    }
+}
+
+@end

--- a/Classes/Core/KWFormatter.m
+++ b/Classes/Core/KWFormatter.m
@@ -34,7 +34,7 @@
 }
 
 
-#pragma mark - Private
+#pragma mark - Internal Methods
 
 + (NSString *)formattedCollection:(id<NSFastEnumeration>)collection {
 

--- a/Classes/Core/KWMatcherFactory.m
+++ b/Classes/Core/KWMatcherFactory.m
@@ -117,7 +117,7 @@
     return [[matcherClass alloc] initWithSubject:subject];
 }
 
-#pragma mark - Private methods
+#pragma mark - Internal Methods
 
 - (Class)matcherClassForSelector:(SEL)aSelector subject:(id)anObject {
     NSArray *matcherClassChain = self.matcherClassChains[NSStringFromSelector(aSelector)];

--- a/Classes/Core/KWStringUtilities.h
+++ b/Classes/Core/KWStringUtilities.h
@@ -15,5 +15,4 @@ BOOL KWStringHasWord(NSString *string, NSString *word);
 #pragma mark - Getting Type Encodings
 
 NSString *KWEncodingWithObjCTypes(const char *firstType, ...) NS_REQUIRES_NIL_TERMINATION;
-NSString *KWEncodingForVoidMethod(void);
 NSString *KWEncodingForDefaultMethod(void);

--- a/Classes/Core/KWStringUtilities.m
+++ b/Classes/Core/KWStringUtilities.m
@@ -83,10 +83,6 @@ NSString *KWEncodingWithObjCTypes(const char *firstType, ...) {
     return encoding;
 }
 
-NSString *KWEncodingForVoidMethod(void) {
-    return KWEncodingWithObjCTypes(@encode(void), @encode(id), @encode(SEL), nil);
-}
-
 NSString *KWEncodingForDefaultMethod(void) {
     return KWEncodingWithObjCTypes(@encode(id), @encode(id), @encode(SEL), nil);
 }

--- a/Classes/Core/Kiwi.h
+++ b/Classes/Core/Kiwi.h
@@ -43,6 +43,7 @@ extern "C" {
 #import "KWExampleSuiteBuilder.h"
 #import "KWExampleNode.h"
 #import "KWExampleNodeVisitor.h"
+#import "KWSharedExample.h"
 #import "KWExistVerifier.h"
 #import "KWExpectationType.h"
 #import "KWFailure.h"

--- a/Classes/Core/KiwiMacros.h
+++ b/Classes/Core/KiwiMacros.h
@@ -29,9 +29,9 @@
 #pragma mark - Support Macros
 
 #define KW_THIS_CALLSITE [KWCallSite callSiteWithFilename:@__FILE__ lineNumber:__LINE__]
-#define KW_ADD_EXIST_VERIFIER(expectationType) [self addExistVerifierWithExpectationType:expectationType callSite:KW_THIS_CALLSITE] 
-#define KW_ADD_MATCH_VERIFIER(expectationType) [self addMatchVerifierWithExpectationType:expectationType callSite:KW_THIS_CALLSITE]
-#define KW_ADD_ASYNC_VERIFIER(expectationType, timeOut, wait) [self addAsyncVerifierWithExpectationType:expectationType callSite:KW_THIS_CALLSITE timeout:timeOut shouldWait:wait]
+#define KW_ADD_EXIST_VERIFIER(expectationType) [KWSpec addExistVerifierWithExpectationType:expectationType callSite:KW_THIS_CALLSITE]
+#define KW_ADD_MATCH_VERIFIER(expectationType) [KWSpec addMatchVerifierWithExpectationType:expectationType callSite:KW_THIS_CALLSITE]
+#define KW_ADD_ASYNC_VERIFIER(expectationType, timeOut, wait) [KWSpec addAsyncVerifierWithExpectationType:expectationType callSite:KW_THIS_CALLSITE timeout:timeOut shouldWait:wait]
 
 #pragma mark - Keywords
 
@@ -109,3 +109,21 @@
     } \
     \
     @end
+
+// Used to ensure that shared examples are registered before any
+// examples are evaluated. The name parameter is not used except
+// to define a category. Therefore, it must be unique.
+#define SHARED_EXAMPLES_BEGIN(name) \
+    \
+    @interface KWSharedExample (name) \
+    \
+    @end \
+    \
+    @implementation KWSharedExample (name) \
+    \
+    + (void)load { \
+
+#define SHARED_EXAMPLES_END \
+    } \
+    \
+    @end \

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -563,6 +563,13 @@
 		DAA1B3B018CF25C00015CF7A /* KWNotificationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA1B3AE18CF25C00015CF7A /* KWNotificationMatcher.m */; };
 		DAA1B3B118CF29770015CF7A /* KWNotificationMatcher.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DAA1B3AD18CF25C00015CF7A /* KWNotificationMatcher.h */; };
 		DAAC61CB17E75B50000165F6 /* KWObjCUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DAAC61CA17E75B50000165F6 /* KWObjCUtilitiesTest.m */; };
+		DA3EAD0818A7A1D700EBBF57 /* KWSharedExampleFunctionalTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DA3EAD0718A7A1D700EBBF57 /* KWSharedExampleFunctionalTest.m */; };
+        DAB1AF9418A53E2400CACD90 /* KWSharedExample.h in Headers */ = {isa = PBXBuildFile; fileRef = DAB1AF9018A53E2400CACD90 /* KWSharedExample.h */; };
+		DAB1AF9518A53E2400CACD90 /* KWSharedExample.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB1AF9118A53E2400CACD90 /* KWSharedExample.m */; };
+		DAB1AF9618A53E2400CACD90 /* KWSharedExampleRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = DAB1AF9218A53E2400CACD90 /* KWSharedExampleRegistry.h */; };
+		DAB1AF9718A53E2400CACD90 /* KWSharedExampleRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB1AF9318A53E2400CACD90 /* KWSharedExampleRegistry.m */; };
+		DAB1AF9B18A53E9900CACD90 /* KWSharedExampleRegistryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB1AF9918A53E9900CACD90 /* KWSharedExampleRegistryTest.m */; };
+		DAB1AF9C18A53E9900CACD90 /* KWSharedExampleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB1AF9A18A53E9900CACD90 /* KWSharedExampleTest.m */; };
 		F5015CBD1158404E002E9A98 /* libKiwi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F5015B9F11583A77002E9A98 /* libKiwi.a */; };
 		F53B5E43115B33FC0022BC0B /* KWContainMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F53B5E42115B33FC0022BC0B /* KWContainMatcherTest.m */; };
 		F53B5E66115B36EB0022BC0B /* KWEqualMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F53B5E65115B36EB0022BC0B /* KWEqualMatcherTest.m */; };
@@ -954,7 +961,14 @@
 		DAA1B3AD18CF25C00015CF7A /* KWNotificationMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWNotificationMatcher.h; sourceTree = "<group>"; };
 		DAA1B3AE18CF25C00015CF7A /* KWNotificationMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWNotificationMatcher.m; sourceTree = "<group>"; };
 		DAAC61CA17E75B50000165F6 /* KWObjCUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWObjCUtilitiesTest.m; sourceTree = "<group>"; };
-		F5015B9F11583A77002E9A98 /* libKiwi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKiwi.a; sourceTree = BUILT_PRODUCTS_DIR; };
+        DA3EAD0718A7A1D700EBBF57 /* KWSharedExampleFunctionalTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWSharedExampleFunctionalTest.m; sourceTree = "<group>"; };
+		DAB1AF9018A53E2400CACD90 /* KWSharedExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWSharedExample.h; sourceTree = "<group>"; };
+		DAB1AF9118A53E2400CACD90 /* KWSharedExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWSharedExample.m; sourceTree = "<group>"; };
+		DAB1AF9218A53E2400CACD90 /* KWSharedExampleRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWSharedExampleRegistry.h; sourceTree = "<group>"; };
+		DAB1AF9318A53E2400CACD90 /* KWSharedExampleRegistry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWSharedExampleRegistry.m; sourceTree = "<group>"; };
+		DAB1AF9918A53E9900CACD90 /* KWSharedExampleRegistryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWSharedExampleRegistryTest.m; sourceTree = "<group>"; };
+		DAB1AF9A18A53E9900CACD90 /* KWSharedExampleTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWSharedExampleTest.m; sourceTree = "<group>"; };
+        F5015B9F11583A77002E9A98 /* libKiwi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKiwi.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F5015C9E11584017002E9A98 /* KiwiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KiwiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F508565011BE61A1000EAD4E /* KiwiTestConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KiwiTestConfiguration.h; sourceTree = "<group>"; };
 		F51A59BE1191D45500598B04 /* KWRealObjectStubTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWRealObjectStubTest.m; sourceTree = "<group>"; };
@@ -1105,6 +1119,7 @@
 			children = (
 				C533F7D117462CAA000CAB02 /* KWSymbolicator.h */,
 				C533F7D217462CAA000CAB02 /* KWSymbolicator.m */,
+				DAB1AF8F18A53E2400CACD90 /* Examples */,
 				9F982C3A16A802920030A0B1 /* Kiwi.h */,
 				9F982C3B16A802920030A0B1 /* KiwiBlockMacros.h */,
 				9F982C3C16A802920030A0B1 /* KiwiConfiguration.h */,
@@ -1356,6 +1371,27 @@
 			path = "Xcode Templates/Kiwi Spec.xctemplate";
 			sourceTree = "<group>";
 		};
+		DAB1AF8F18A53E2400CACD90 /* Examples */ = {
+			isa = PBXGroup;
+			children = (
+				DAB1AF9018A53E2400CACD90 /* KWSharedExample.h */,
+				DAB1AF9118A53E2400CACD90 /* KWSharedExample.m */,
+				DAB1AF9218A53E2400CACD90 /* KWSharedExampleRegistry.h */,
+				DAB1AF9318A53E2400CACD90 /* KWSharedExampleRegistry.m */,
+			);
+			path = Examples;
+			sourceTree = "<group>";
+		};
+		DAB1AF9818A53E9900CACD90 /* Shared Examples */ = {
+			isa = PBXGroup;
+			children = (
+				DAB1AF9918A53E9900CACD90 /* KWSharedExampleRegistryTest.m */,
+				DAB1AF9A18A53E9900CACD90 /* KWSharedExampleTest.m */,
+				DA3EAD0718A7A1D700EBBF57 /* KWSharedExampleFunctionalTest.m */,
+			);
+			path = "Shared Examples";
+			sourceTree = "<group>";
+		};
 		F5015B4D1158396B002E9A98 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1375,6 +1411,7 @@
 			children = (
 				F5A9EFD211741E7700E9EDA3 /* Matchers */,
 				F5A1E6081174322A002223E1 /* Mocks, Stubs, and Spying */,
+				DAB1AF9818A53E9900CACD90 /* Shared Examples */,
 				89F9CB7816B1BE0E00E87D34 /* Functional */,
 				080E96DDFE201D6D7F000001 /* Test Classes */,
 				F5BDB84711C0C8CE00DD3474 /* Example Groups */,
@@ -1566,6 +1603,7 @@
 			files = (
 				9F982CE016A802920030A0B1 /* Kiwi.h in Headers */,
 				88E0EC571852D281008E998A /* KWLet.h in Headers */,
+				DAB1AF9618A53E2400CACD90 /* KWSharedExampleRegistry.h in Headers */,
 				9F982CE216A802920030A0B1 /* KiwiBlockMacros.h in Headers */,
 				9F982CE416A802920030A0B1 /* KiwiConfiguration.h in Headers */,
 				9F982CE616A802920030A0B1 /* KiwiMacros.h in Headers */,
@@ -1660,6 +1698,7 @@
 				4E7659AA172DAC6500105B93 /* KWContainStringMatcher.h in Headers */,
 				C533F7D317462CAA000CAB02 /* KWSymbolicator.h in Headers */,
 				37828763177F860B00BCD40F /* Kiwi-Prefix.pch in Headers */,
+				DAB1AF9418A53E2400CACD90 /* KWSharedExample.h in Headers */,
 				4A71048017CC016600A7B718 /* KWLetNode.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2035,6 +2074,7 @@
 				9F982D7E16A802920030A0B1 /* KWGenericMatcher.m in Sources */,
 				9F982D8216A802920030A0B1 /* KWGenericMatchingAdditions.m in Sources */,
 				9F982D8616A802920030A0B1 /* KWHaveMatcher.m in Sources */,
+				DAB1AF9518A53E2400CACD90 /* KWSharedExample.m in Sources */,
 				9F982D8A16A802920030A0B1 /* KWHaveValueMatcher.m in Sources */,
 				9F982D9016A802920030A0B1 /* KWInequalityMatcher.m in Sources */,
 				9F982D9416A802920030A0B1 /* KWIntercept.m in Sources */,
@@ -2078,6 +2118,7 @@
 				4AD7A2251962B14B005ED93F /* KWAllTestsSuite.m in Sources */,
 				4E7659AB172DAC6500105B93 /* KWContainStringMatcher.m in Sources */,
 				C533F7D517462CAA000CAB02 /* KWSymbolicator.m in Sources */,
+				DAB1AF9718A53E2400CACD90 /* KWSharedExampleRegistry.m in Sources */,
 				4A8699B917E9B3CE007F250E /* KWLetNode.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2093,6 +2134,7 @@
 				4ACDA433195EC73C006B385D /* KWPendingNodeTest.m in Sources */,
 				F5D7C8D411643C2900758FEA /* KWDeviceInfoTest.m in Sources */,
 				F54A4B1E11733D98002442C5 /* KWBeKindOfClassMatcherTest.m in Sources */,
+				DAB1AF9B18A53E9900CACD90 /* KWSharedExampleRegistryTest.m in Sources */,
 				F54A4BD511734750002442C5 /* KWBeMemberOfClassMatcherTest.m in Sources */,
 				F54A4C0111734975002442C5 /* KWConformToProtocolMatcherTest.m in Sources */,
 				F5A1E67911743B92002223E1 /* KWBeWithinMatcherTest.m in Sources */,
@@ -2129,6 +2171,7 @@
 				DA9C69F8190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m in Sources */,
 				9F982A3C16A801800030A0B1 /* Galaxy.m in Sources */,
 				9F982A3D16A801800030A0B1 /* KiwiAppDelegate.m in Sources */,
+				DAB1AF9C18A53E9900CACD90 /* KWSharedExampleTest.m in Sources */,
 				9F982A3E16A801800030A0B1 /* KiwiViewController.m in Sources */,
 				9F982A3F16A801800030A0B1 /* Robot.m in Sources */,
 				9F982A4016A801800030A0B1 /* SpaceShip.m in Sources */,
@@ -2140,6 +2183,7 @@
 				4AF96EF1195E98880010D605 /* KWBlockNodeTest.m in Sources */,
 				89861D9416FE0EE5008CE99D /* KWFormatterTest.m in Sources */,
 				3AD0490318D8C4CA00D12A08 /* KWExampleTest.m in Sources */,
+				DA3EAD0818A7A1D700EBBF57 /* KWSharedExampleFunctionalTest.m in Sources */,
 				C10F0370170C7C2D0031FE64 /* KWBeSubclassOfClassMatcherTest.m in Sources */,
 				4E3C5DB81716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m in Sources */,
 				4E7659B0172DAE4D00105B93 /* KWContainStringMatcherTest.m in Sources */,

--- a/Tests/Shared Examples/KWSharedExampleFunctionalTest.m
+++ b/Tests/Shared Examples/KWSharedExampleFunctionalTest.m
@@ -11,21 +11,21 @@
 SPEC_BEGIN(KWSharedExampleFunctionalTest)
 
 describe(@"Cruiser", ^{
-    itBehavesLike(@"a cruiser", [Cruiser class]);
+    itBehavesLike(@"a cruiser", @{ @"class": [Cruiser class] });
 });
 
 describe(@"Carrier", ^{
-    itBehavesLike(@"a cruiser", [Carrier class]);
+    itBehavesLike(@"a cruiser", @{ @"class": [Carrier class] });
 });
 
 SPEC_END
 
 SHARED_EXAMPLES_BEGIN(TestClasses)
 
-sharedExamplesFor(@"a cruiser", ^(Class describedClass) {
+sharedExamplesFor(@"a cruiser", ^(NSDictionary *data) {
     __block Cruiser *cruiser = nil;
     beforeEach(^{
-        cruiser = [[describedClass alloc] initWithCallsign:@"Planet Express"];
+        cruiser = [[data[@"class"] alloc] initWithCallsign:@"Planet Express"];
     });
 
     it(@"has a callsign", ^{

--- a/Tests/Shared Examples/KWSharedExampleFunctionalTest.m
+++ b/Tests/Shared Examples/KWSharedExampleFunctionalTest.m
@@ -1,0 +1,36 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import "Kiwi.h"
+#import "Cruiser.h"
+#import "Carrier.h"
+
+SPEC_BEGIN(KWSharedExampleFunctionalTest)
+
+describe(@"Cruiser", ^{
+    itBehavesLike(@"a cruiser", [Cruiser class]);
+});
+
+describe(@"Carrier", ^{
+    itBehavesLike(@"a cruiser", [Carrier class]);
+});
+
+SPEC_END
+
+SHARED_EXAMPLES_BEGIN(TestClasses)
+
+sharedExamplesFor(@"a cruiser", ^(Class describedClass) {
+    __block Cruiser *cruiser = nil;
+    beforeEach(^{
+        cruiser = [[describedClass alloc] initWithCallsign:@"Planet Express"];
+    });
+
+    it(@"has a callsign", ^{
+        [[cruiser.callsign should] equal:@"Planet Express"];
+    });
+});
+
+SHARED_EXAMPLES_END

--- a/Tests/Shared Examples/KWSharedExampleRegistryTest.m
+++ b/Tests/Shared Examples/KWSharedExampleRegistryTest.m
@@ -17,7 +17,7 @@
 
 - (void)testRegisterSharedExample {
     KWSharedExample *sharedExample = [[KWSharedExample alloc] initWithName:@"LGTM"
-                                                                     block:^(Class describedClass) {}];
+                                                                     block:^(NSDictionary *data) {}];
     [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:sharedExample];
     
     XCTAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"LGTM"],
@@ -28,12 +28,12 @@
 - (void)testRegisterSharedExampleWithSameNameRaises {
     KWSharedExample *firstSharedExample =
     [[KWSharedExample alloc] initWithName:@"ASAP"
-                                    block:^(Class describedClass) {
+                                    block:^(NSDictionary *data) {
                                         NSLog(@"This example will be registered.");
                                     }];
     KWSharedExample *secondSharedExample =
     [[KWSharedExample alloc] initWithName:@"ASAP"
-                                    block:^(Class describedClass) {
+                                    block:^(NSDictionary *data) {
                                         NSLog(@"This example will throw.");
                                     }];
     

--- a/Tests/Shared Examples/KWSharedExampleRegistryTest.m
+++ b/Tests/Shared Examples/KWSharedExampleRegistryTest.m
@@ -4,11 +4,12 @@
 // Copyright 2014 Allen Ding. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import "Kiwi.h"
+#import "KiwiTestConfiguration.h"
 #import "KWSharedExampleRegistry.h"
 #import "KWSharedExample.h"
 
-@interface KWSharedExampleRegistryTest : SenTestCase
+@interface KWSharedExampleRegistryTest : XCTestCase
 
 @end
 
@@ -18,32 +19,32 @@
     KWSharedExample *sharedExample = [[KWSharedExample alloc] initWithName:@"LGTM"
                                                                      block:^(Class describedClass) {}];
     [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:sharedExample];
-
-    STAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"LGTM"],
-                         sharedExample,
-                         @"Shared example was not registered.");
+    
+    XCTAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"LGTM"],
+                          sharedExample,
+                          @"Shared example was not registered.");
 }
 
 - (void)testRegisterSharedExampleWithSameNameRaises {
     KWSharedExample *firstSharedExample =
-        [[KWSharedExample alloc] initWithName:@"ASAP"
-                                        block:^(Class describedClass) {
-                                            NSLog(@"This example will be registered.");
-                                        }];
+    [[KWSharedExample alloc] initWithName:@"ASAP"
+                                    block:^(Class describedClass) {
+                                        NSLog(@"This example will be registered.");
+                                    }];
     KWSharedExample *secondSharedExample =
-        [[KWSharedExample alloc] initWithName:@"ASAP"
-                                        block:^(Class describedClass) {
-                                            NSLog(@"This example will throw.");
-                                        }];
-
+    [[KWSharedExample alloc] initWithName:@"ASAP"
+                                    block:^(Class describedClass) {
+                                        NSLog(@"This example will throw.");
+                                    }];
+    
     [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:firstSharedExample];
-    STAssertThrows([[KWSharedExampleRegistry sharedRegistry] registerSharedExample:secondSharedExample],
-                   @"Registering shared example with identical name did not raise.");
+    XCTAssertThrows([[KWSharedExampleRegistry sharedRegistry] registerSharedExample:secondSharedExample],
+                    @"Registering shared example with identical name did not raise.");
 }
 
 - (void)testSharedExampleLookupRaisesIfNonexistent {
-    STAssertThrows([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"XHTML"],
-                   @"Lookup for unregistered shared example did not raise.");
+    XCTAssertThrows([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"XHTML"],
+                    @"Lookup for unregistered shared example did not raise.");
 }
 
 @end

--- a/Tests/Shared Examples/KWSharedExampleRegistryTest.m
+++ b/Tests/Shared Examples/KWSharedExampleRegistryTest.m
@@ -1,0 +1,49 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "KWSharedExampleRegistry.h"
+#import "KWSharedExample.h"
+
+@interface KWSharedExampleRegistryTest : SenTestCase
+
+@end
+
+@implementation KWSharedExampleRegistryTest
+
+- (void)testRegisterSharedExample {
+    KWSharedExample *sharedExample = [[KWSharedExample alloc] initWithName:@"LGTM"
+                                                                     block:^(Class describedClass) {}];
+    [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:sharedExample];
+
+    STAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"LGTM"],
+                         sharedExample,
+                         @"Shared example was not registered.");
+}
+
+- (void)testRegisterSharedExampleWithSameNameRaises {
+    KWSharedExample *firstSharedExample =
+        [[KWSharedExample alloc] initWithName:@"ASAP"
+                                        block:^(Class describedClass) {
+                                            NSLog(@"This example will be registered.");
+                                        }];
+    KWSharedExample *secondSharedExample =
+        [[KWSharedExample alloc] initWithName:@"ASAP"
+                                        block:^(Class describedClass) {
+                                            NSLog(@"This example will throw.");
+                                        }];
+
+    [[KWSharedExampleRegistry sharedRegistry] registerSharedExample:firstSharedExample];
+    STAssertThrows([[KWSharedExampleRegistry sharedRegistry] registerSharedExample:secondSharedExample],
+                   @"Registering shared example with identical name did not raise.");
+}
+
+- (void)testSharedExampleLookupRaisesIfNonexistent {
+    STAssertThrows([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"XHTML"],
+                   @"Lookup for unregistered shared example did not raise.");
+}
+
+@end

--- a/Tests/Shared Examples/KWSharedExampleTest.m
+++ b/Tests/Shared Examples/KWSharedExampleTest.m
@@ -4,33 +4,34 @@
 // Copyright 2014 Allen Ding. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import "Kiwi.h"
+#import "KiwiTestConfiguration.h"
 #import "KWSharedExample.h"
 #import "KWSharedExampleRegistry.h"
 #import "KWExample.h"
 
-@interface KWSharedExampleTest : SenTestCase
+@interface KWSharedExampleTest : XCTestCase
 
 @end
 
 @implementation KWSharedExampleTest
 
 - (void)testSharedExampleMustHaveNameParameter {
-    STAssertThrows([[KWSharedExample alloc] initWithName:nil block:nil],
-                   @"Unnamed shared example was created");
+    XCTAssertThrows([[KWSharedExample alloc] initWithName:nil block:nil],
+                    @"Unnamed shared example was created");
 }
 
 - (void)testSharedExampleMustHaveBlockParameter {
-    STAssertThrows([[KWSharedExample alloc] initWithName:@"FTW"
-                                                   block:nil],
-                   @"Shared example was created without a corresponding context block");
+    XCTAssertThrows([[KWSharedExample alloc] initWithName:@"FTW"
+                                                    block:nil],
+                    @"Shared example was created without a corresponding context block");
 }
 
 - (void)testSharedExamplesForRegistersTheSharedExample {
     sharedExamplesFor(@"FTTP", ^(Class sharedExample) {});
-    STAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"FTTP"].name,
-                         @"FTTP",
-                         @"Shared example was not registered.");
+    XCTAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"FTTP"].name,
+                          @"FTTP",
+                          @"Shared example was not registered.");
 }
 
 - (void)testItBehavesLikeExecutesTheBlock {
@@ -43,9 +44,9 @@
             blockWasCalled = @YES;
         });
     });
-
-    STAssertFalse([blockWasCalled boolValue],
-                  @"Blocks in shared example were executed prematurely.");
+    
+    XCTAssertFalse([blockWasCalled boolValue],
+                   @"Blocks in shared example were executed prematurely.");
 }
 
 @end

--- a/Tests/Shared Examples/KWSharedExampleTest.m
+++ b/Tests/Shared Examples/KWSharedExampleTest.m
@@ -36,7 +36,7 @@
 
 - (void)testItBehavesLikeExecutesTheBlock {
     __block NSNumber *blockWasCalled = @NO;
-    sharedExamplesFor(@"ESP", ^(Class describedClass) {
+    sharedExamplesFor(@"ESP", ^(NSDictionary *data) {
         beforeAll(^{
             blockWasCalled = @YES;
         });

--- a/Tests/Shared Examples/KWSharedExampleTest.m
+++ b/Tests/Shared Examples/KWSharedExampleTest.m
@@ -1,0 +1,51 @@
+//
+// Licensed under the terms in License.txt
+//
+// Copyright 2014 Allen Ding. All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "KWSharedExample.h"
+#import "KWSharedExampleRegistry.h"
+#import "KWExample.h"
+
+@interface KWSharedExampleTest : SenTestCase
+
+@end
+
+@implementation KWSharedExampleTest
+
+- (void)testSharedExampleMustHaveNameParameter {
+    STAssertThrows([[KWSharedExample alloc] initWithName:nil block:nil],
+                   @"Unnamed shared example was created");
+}
+
+- (void)testSharedExampleMustHaveBlockParameter {
+    STAssertThrows([[KWSharedExample alloc] initWithName:@"FTW"
+                                                   block:nil],
+                   @"Shared example was created without a corresponding context block");
+}
+
+- (void)testSharedExamplesForRegistersTheSharedExample {
+    sharedExamplesFor(@"FTTP", ^(Class sharedExample) {});
+    STAssertEqualObjects([[KWSharedExampleRegistry sharedRegistry] sharedExampleForName:@"FTTP"].name,
+                         @"FTTP",
+                         @"Shared example was not registered.");
+}
+
+- (void)testItBehavesLikeExecutesTheBlock {
+    __block NSNumber *blockWasCalled = @NO;
+    sharedExamplesFor(@"ESP", ^(Class describedClass) {
+        beforeAll(^{
+            blockWasCalled = @YES;
+        });
+        context(@"with LSD", ^{
+            blockWasCalled = @YES;
+        });
+    });
+
+    STAssertFalse([blockWasCalled boolValue],
+                  @"Blocks in shared example were executed prematurely.");
+}
+
+@end


### PR DESCRIPTION
This PR adds shared examples to the latest version of ```Kiwi``` ([2.3.1](https://github.com/kiwi-bdd/Kiwi/releases/tag/2.3.1)). It is based on the original implementation proposed by @modocache in #442.

Shared examples allow developers to reuse a set of describe, context, and it nodes to test one or more classes. See the functional tests in ```Tests/Shared Examples/KWSharedExampleFunctionalTest.m``` for sample usage.

Addresses issues #175, #138.

## Implementation Details
- ```KWSharedExampleRegistry``` is a singleton that maintains a mapping of shared example names to ```KWSharedExample``` instances.
- ```KWSharedExample``` is a data structure composed of a name and context block.
- ```sharedExamplesFor``` creates a ```KWSharedExample``` and registers it.
- ```itBehavesLike``` looks up the ```KWSharedExample``` with the given name and inserts its context block into the current example group.
- ```SHARED_EXAMPLES_BEGIN```, ```SHARED_EXAMPLES_END``` macros are used to ensure ```sharedExamplesFor``` are evaluated prior to any examples.
- In order to allow assertion macros like should to be compiled outside of the implementation block of a ```KWSpec```--like within ```sharedExamplesFor```, for example--changed macro to reference global state by using ```KWSpec``` class method.
- Changed all pragma marks referencing internal/private methods to Internal Methods.
- Removed unused ```KWEncodingForVoidMethod``` function.

## Sample Usage
```Obj-C
// CruiserSpecHelpers.m

SHARED_EXAMPLES_BEGIN(CruiserSpecHelpers)

sharedExamplesFor(@"a cruiser", ^(NSDictionary *data) {
    __block Cruiser *cruiser = nil;
    beforeEach(^{
        cruiser = [[data[@"class"] alloc] initWithCallsign:@"Planet Express"];
    });

    it(@"has a callsign", ^{
        [[cruiser.callsign should] equal:@"Planet Express"];
    });
});

SHARED_EXAMPLES_END
```

```Obj-C
// CruiserSpec.m

SPEC_BEGIN(CruiserSpec)

describe(@"Cruiser", ^{
    itBehavesLike(@"a cruiser", @{ @"class": [Cruiser class] });
});

describe(@"Carrier", ^{
    itBehavesLike(@"a cruiser", @{ @"class": [Carrier class] });
});

SPEC_END
```

## Additional Information

There is a known issue with the current implementation that affects line highlighting when a failure occurs.

For more information you can visit the original PR #442.