### PR TITLE
support x86_64 return calling conventions

### DIFF
--- a/Classes/Stubbing/KWIntercept.m
+++ b/Classes/Stubbing/KWIntercept.m
@@ -63,7 +63,7 @@ IMP KWForwardingImplementationForMethodEncoding(const char* encoding) {
 #elif TARGET_CPU_X86
     const NSUInteger stretLengthThreshold = 8;
 #elif TARGET_CPU_X86_64
-        const NSUInteger stretLengthThreshold = 16;
+    const NSUInteger stretLengthThreshold = 16;
 #else
     // TODO: This just makes an assumption right now. Expand to support all
     // official architectures correctly.

--- a/Classes/Stubbing/KWIntercept.m
+++ b/Classes/Stubbing/KWIntercept.m
@@ -62,6 +62,8 @@ IMP KWForwardingImplementationForMethodEncoding(const char* encoding) {
     const NSUInteger stretLengthThreshold = 4;
 #elif TARGET_CPU_X86
     const NSUInteger stretLengthThreshold = 8;
+#elif TARGET_CPU_X86_64
+        const NSUInteger stretLengthThreshold = 16;
 #else
     // TODO: This just makes an assumption right now. Expand to support all
     // official architectures correctly.


### PR DESCRIPTION
Covers issues that arise when structs are larger than 8 bytes are returned on the call stack on x86_64 targets.  I'm not sure if there may be other places this comes up, but I think this is a start.