### PR TITLE
Working around crash when using Kiwi with Google Analytics (#637)

### DIFF
--- a/Classes/Core/KWMatcherFactory.m
+++ b/Classes/Core/KWMatcherFactory.m
@@ -71,7 +71,7 @@
             Class candidateClass = classes[i];
 
             // GAITrackerModel blacklisted due to crash causes when +initialize called on this class 
-            if (candidateClass == NSClassFromString(@"GAITrackerModel"))
+            if ([NSStringFromClass(candidateClass) isEqualToString:@"GAITrackerModel"])
                 continue;
             
             if (!class_respondsToSelector(candidateClass, @selector(conformsToProtocol:)))

--- a/Classes/Core/KWMatcherFactory.m
+++ b/Classes/Core/KWMatcherFactory.m
@@ -70,6 +70,10 @@
         for (int i = 0; i < numberOfClasses; ++i) {
             Class candidateClass = classes[i];
 
+            // GAITrackerModel blacklisted due to crash causes when +initialize called on this class 
+            if (candidateClass == NSClassFromString(@"GAITrackerModel"))
+                continue;
+            
             if (!class_respondsToSelector(candidateClass, @selector(conformsToProtocol:)))
                 continue;
 


### PR DESCRIPTION
Working around a crash in GoogleAnalytics when one of its classes +initialize method is called. 

Although I'm reluctant to propose a Google Analytics specific fix, based on discussion on #637 it appears other components have problems with this code. Perhaps a generalized blacklist of classes would be worth looking into? 