### PR TITLE
allow use of notification matcher with async verifier in constructs l…

### DIFF
--- a/Classes/Matchers/KWNotificationMatcher.h
+++ b/Classes/Matchers/KWNotificationMatcher.h
@@ -17,4 +17,6 @@ typedef void (^PostedNotificationBlock)(NSNotification* note);
 - (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo;
 - (void)bePostedEvaluatingBlock:(PostedNotificationBlock)block;
 
+#pragma mark - KWMatching
+@property (nonatomic, assign) BOOL willEvaluateMultipleTimes;
 @end

--- a/Classes/Matchers/KWNotificationMatcher.m
+++ b/Classes/Matchers/KWNotificationMatcher.m
@@ -40,14 +40,30 @@
                                         if (self.evaluationBlock) {
                                             self.evaluationBlock(note);
                                         }
+                                        if (self.didReceiveNotification) {
+                                            [self removeObserver];
+                                        }
                                     }];
+}
+
+- (void)removeObserver {
+    if (self.observer) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self.observer];
+        self.observer = nil;
+    }
 }
 
 #pragma mark - Matching
 
 - (BOOL)evaluate {
-    [[NSNotificationCenter defaultCenter] removeObserver:self.observer];
+    if (!self.willEvaluateMultipleTimes) {
+        [self removeObserver];
+    }
     return self.didReceiveNotification;
+}
+
+- (void)dealloc {
+    [self removeObserver];
 }
 
 - (BOOL)shouldBeEvaluatedAtEndOfExample {


### PR DESCRIPTION
…ike [[@"my notification" shouldEventually] bePosted]; or even shouldNotEventually by keeping observer alive when evaluted multiple times until first notification received

Resolve #592 
