### PR TITLE
Removed @autorelease block to avoid EXC_BAD_ACCESS crash

### DIFF
--- a/Classes/Core/KWSpec.m
+++ b/Classes/Core/KWSpec.m
@@ -115,15 +115,13 @@
 - (void)runExample {
     self.currentExample = self.invocation.kw_example;
 
-    @autoreleasepool {
-        @try {
-            [self.currentExample runWithDelegate:self];
-        } @catch (NSException *exception) {
-            [self recordFailureWithDescription:exception.description inFile:@"" atLine:0 expected:NO];
-        }
-
-        self.invocation.kw_example = nil;
+    @try {
+        [self.currentExample runWithDelegate:self];
+    } @catch (NSException *exception) {
+        [self recordFailureWithDescription:exception.description inFile:@"" atLine:0 expected:NO];
     }
+    
+    self.invocation.kw_example = nil;
 }
 
 #pragma mark - KWExampleGroupDelegate methods


### PR DESCRIPTION
This may be related to #571 

Platform: 
- Mac OS X 10.10.5 (**Mac** application)
- Xcode 7.0 GM
- Kiwi HEAD based on 2.4.0 (I believe the sha1 is `ae9f6d83faf774754ea60a9dfc6556eb23800f47`)

**NOTE:** This issue was raised while running tests against a **Mac** application.

I got a **VERY RELIABLE** `EXC_BAD_ACCESS (code=EXC_I386_GPFLT)` memory crash in `-[KWSpec runExample]`.

It seems as if the `@autoreleasepool` block may be a little over-aggressive in releasing either `self.currentExample` or `self.invocation`.

When I commented out the `@autorelease` block, everything worked fine.

Here's the backtrace on the original `EXC_BAD_ACCESS`:

```
* thread #1: tid = 0xbb3cdc, 0x00007fff8bc3944c libobjc.A.dylib`objc_release + 12, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
    frame #0: 0x00007fff8bc3944c libobjc.A.dylib`objc_release + 12
    frame #1: 0x00007fff8bc37e8f libobjc.A.dylib`(anonymous namespace)::AutoreleasePoolPage::pop(void*) + 575
  * frame #2: 0x000000010c27b976 SingularityOneTests`-[KWSpec runExample](self=0x000000010c947cb0, _cmd="BasicMechanics_LoadDataForWeekOfAug30_2015") + 310 at KWSpec.m:126
    frame #3: 0x00007fff8e5997bc CoreFoundation`__invoking___ + 140
    frame #4: 0x00007fff8e599612 CoreFoundation`-[NSInvocation invoke] + 290
    frame #5: 0x00000001006edb53 XCTest`__24-[XCTestCase invokeTest]_block_invoke_2 + 159
    frame #6: 0x0000000100720026 XCTest`-[XCTestContext performInScope:] + 184
    frame #7: 0x00000001006edaa3 XCTest`-[XCTestCase invokeTest] + 169
    frame #8: 0x00000001006edf3e XCTest`-[XCTestCase performTest:] + 443
    frame #9: 0x00000001006ebc0f XCTest`-[XCTestSuite performTest:] + 377
    frame #10: 0x00000001006ebc0f XCTest`-[XCTestSuite performTest:] + 377
    frame #11: 0x00000001006ebc0f XCTest`-[XCTestSuite performTest:] + 377
    frame #12: 0x00000001006da5c3 XCTest`__25-[XCTestDriver _runSuite]_block_invoke + 51
    frame #13: 0x00000001006fe736 XCTest`-[XCTestObservationCenter _observeTestExecutionForBlock:] + 611
    frame #14: 0x00000001006da50c XCTest`-[XCTestDriver _runSuite] + 408
    frame #15: 0x00000001006db0bb XCTest`-[XCTestDriver _checkForTestManager] + 696
    frame #16: 0x0000000100721273 XCTest`_XCTestMain + 628
    frame #17: 0x00007fff8e5de8ec CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
    frame #18: 0x00007fff8e5d09f5 CoreFoundation`__CFRunLoopDoBlocks + 341
    frame #19: 0x00007fff8e5d01ae CoreFoundation`__CFRunLoopRun + 910
    frame #20: 0x00007fff8e5cfbd8 CoreFoundation`CFRunLoopRunSpecific + 296
    frame #21: 0x00007fff8efb856f HIToolbox`RunCurrentEventLoopInMode + 235
    frame #22: 0x00007fff8efb81ee HIToolbox`ReceiveNextEventCommon + 179
    frame #23: 0x00007fff8efb812b HIToolbox`_BlockUntilNextEventMatchingListInModeWithFilter + 71
    frame #24: 0x00007fff8725b8ab AppKit`_DPSNextEvent + 978
    frame #25: 0x00007fff8725ae58 AppKit`-[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:] + 346
    frame #26: 0x00007fff87250af3 AppKit`-[NSApplication run] + 594
    frame #27: 0x00007fff871cd244 AppKit`NSApplicationMain + 1832
    frame #28: 0x000000010001a482 SingularityOne`main(argc=5, argv=0x00007fff5fbff378) + 34 at main.m:13
    frame #29: 0x00007fff8c1575c9 libdyld.dylib`start + 1
    frame #30: 0x00007fff8c1575c9 libdyld.dylib`start + 1
```

NOTE: This issue first appeared when I converted a set of `NSMutableArrays` to `CGFloat *` and created them using `calloc` to speed up performance. (And yes, I did properly `free()` all the pointers in `-dealloc`).

I'm submitting this PR for this issue. Unfortunately, I can't create a test spec because it involves a pretty complex BDD-style test with a large database.
