### PR TITLE
Don't initialize classes when registering matchers

### DIFF
--- a/Classes/Core/KWMatcherFactory.m
+++ b/Classes/Core/KWMatcherFactory.m
@@ -67,16 +67,20 @@
             return;
         }
 
+        Protocol *kiwiMatching = @protocol(KWMatching);
+
         for (int i = 0; i < numberOfClasses; ++i) {
             Class candidateClass = classes[i];
+            Class candidateOrSuper = candidateClass;
 
-            if (!class_respondsToSelector(candidateClass, @selector(conformsToProtocol:)))
-                continue;
+            // Don't use `NSObject#conformsToProtocol:` because it triggers `+initialize` methods to be called.
+            while (candidateOrSuper != nil && class_conformsToProtocol(candidateOrSuper, kiwiMatching) == NO) {
+                candidateOrSuper = class_getSuperclass(candidateOrSuper);
+            }
 
-            if (![candidateClass conformsToProtocol:@protocol(KWMatching)])
-                continue;
-
-            [matcherClasses addObject:candidateClass];
+            if (candidateOrSuper != nil) {
+                [matcherClasses addObject:candidateClass];
+            }
         }
 
         free(classes);

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -247,6 +247,8 @@
 		4AE030C81AEB494400556381 /* KWValueTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C6FD2311782A290068BBC8 /* KWValueTest.m */; };
 		4AE030C91AEB494400556381 /* NSNumber_KiwiAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C69F7190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m */; };
 		4AE030CA1AEB4DCF00556381 /* NSObject+KiwiSpyAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F982CD916A802920030A0B1 /* NSObject+KiwiSpyAdditions.m */; };
+		50ACAF651BBA28D000F29B0F /* DoNotUseMe.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */; settings = {ASSET_TAGS = (); }; };
+		50ACAF661BBA28D000F29B0F /* DoNotUseMe.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */; settings = {ASSET_TAGS = (); }; };
 		CE0736B41B8577140023EBEA /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0736B31B8577140023EBEA /* Expecta.framework */; };
 		CE0736B61B85771E0023EBEA /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0736B51B85771E0023EBEA /* Expecta.framework */; };
 		CE0736B81B8577490023EBEA /* KWExpectaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0736B71B8577490023EBEA /* KWExpectaTests.m */; };
@@ -593,6 +595,8 @@
 		4E7659A8172DAC6500105B93 /* KWContainStringMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWContainStringMatcher.h; sourceTree = "<group>"; };
 		4E7659A9172DAC6500105B93 /* KWContainStringMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWContainStringMatcher.m; sourceTree = "<group>"; };
 		4E7659AF172DAE4D00105B93 /* KWContainStringMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWContainStringMatcherTest.m; sourceTree = "<group>"; };
+		50ACAF631BBA28D000F29B0F /* DoNotUseMe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DoNotUseMe.h; path = "Test Classes/DoNotUseMe.h"; sourceTree = "<group>"; };
+		50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DoNotUseMe.m; path = "Test Classes/DoNotUseMe.m"; sourceTree = "<group>"; };
 		511901A016A95803006E7359 /* KWChangeMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWChangeMatcherTest.m; sourceTree = "<group>"; };
 		511901A316A95CDE006E7359 /* KWChangeMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWChangeMatcher.h; sourceTree = "<group>"; };
 		511901A416A95CDE006E7359 /* KWChangeMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWChangeMatcher.m; sourceTree = "<group>"; };
@@ -895,6 +899,8 @@
 				9F982A1E16A801800030A0B1 /* Carrier.m */,
 				9F982A1F16A801800030A0B1 /* Cruiser.h */,
 				9F982A2016A801800030A0B1 /* Cruiser.m */,
+				50ACAF631BBA28D000F29B0F /* DoNotUseMe.h */,
+				50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */,
 				9F982A2116A801800030A0B1 /* Engine.h */,
 				9F982A2216A801800030A0B1 /* Engine.m */,
 				9F982A2316A801800030A0B1 /* Fighter.h */,
@@ -1878,6 +1884,7 @@
 				4AE030B71AEB494400556381 /* SpaceShip.m in Sources */,
 				4AE030B81AEB494400556381 /* TestReporter.m in Sources */,
 				4AE030B91AEB494400556381 /* TestSpy.m in Sources */,
+				50ACAF661BBA28D000F29B0F /* DoNotUseMe.m in Sources */,
 				4AE030BA1AEB494400556381 /* TestVerifier.m in Sources */,
 				4AE030BB1AEB494400556381 /* KWBlockNodeTest.m in Sources */,
 				4AE030BC1AEB494400556381 /* KWContextNodeTest.m in Sources */,
@@ -2042,6 +2049,7 @@
 				CE87C51F1AF1994200310C07 /* TestReporter.m in Sources */,
 				CE87C5201AF1994200310C07 /* TestSpy.m in Sources */,
 				CE87C5211AF1994200310C07 /* TestVerifier.m in Sources */,
+				50ACAF651BBA28D000F29B0F /* DoNotUseMe.m in Sources */,
 				CE87C5221AF1994200310C07 /* KWBlockNodeTest.m in Sources */,
 				CE87C5231AF1994200310C07 /* KWContextNodeTest.m in Sources */,
 				CE87C5241AF1994200310C07 /* KWExampleSuiteBuilderTest.m in Sources */,

--- a/Tests/Test Classes/DoNotUseMe.h
+++ b/Tests/Test Classes/DoNotUseMe.h
@@ -1,0 +1,13 @@
+//
+//  DoNotUseMe.h
+//  Kiwi
+//
+//  Created by Victor Ilyukevich on 9/28/15.
+//  Copyright © 2015 Allen Ding. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface DoNotUseMe : NSObject
+
+@end

--- a/Tests/Test Classes/DoNotUseMe.m
+++ b/Tests/Test Classes/DoNotUseMe.m
@@ -1,0 +1,18 @@
+//
+//  DoNotUseMe.m
+//  Kiwi
+//
+//  Created by Victor Ilyukevich on 9/28/15.
+//  Copyright © 2015 Allen Ding. All rights reserved.
+//
+
+#import "DoNotUseMe.h"
+
+@implementation DoNotUseMe
+
++ (void)initialize
+{
+    [NSException raise:@"DoNotUseMe" format:@"I'm not supposed to be initialized"];
+}
+
+@end


### PR DESCRIPTION
![2015-09-28_1940](https://cloud.githubusercontent.com/assets/217368/10154207/8aa19bea-6619-11e5-838a-1632e8b2679d.png)

It's possible that a library may have some assertions in theirs `+initialize` methods to help developers to find a potential problem in theirs setup. I.e. Facebook SDK makes sure you have specified required url scheme before you [use FBSDKAppInviteDialog](https://github.com/facebook/facebook-ios-sdk/blob/61b636f61d67337d59741177289cdfe5ec0e5667/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteDialog.m#L35) or [FBSDKShareDialog](https://github.com/facebook/facebook-ios-sdk/blob/61b636f61d67337d59741177289cdfe5ec0e5667/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m#L60), or [FBSDKShareKit/FBSDKMessageDialog](https://github.com/facebook/facebook-ios-sdk/blob/61b636f61d67337d59741177289cdfe5ec0e5667/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.m#L39).

So we've just upgraded to the latest Facebook SDK and have started seeing exceptions when running tests. Those exceptions were exactly in those `+initialize` methods in FB sdk classes. But we don't use those features in our app so we don't need to set up all requirements it asserts for. It works fine when we run our apps because we never call those classes and theirs `+initialize` methods never called.

When we run tests `KWMatcherFactory#registerMatcherClassesWithNamespacePrefix:` is called and it loops through all available classes and check who conforms to `KWMatching` protocol. To check this, it uses `NSObject#conformsToProtocol:` which triggers `+initialize` call.

> + initialize
> Initializes the class before it receives its first message.
> **Discussion**
> The runtime sends initialize to each class in a program just before the class, or any class that inherits from it, is sent its first message from within the program.

This doesn't look right. Kiwi doesn't need to trigger `initialize` methods for every class it can see in runtime. The solution is simply to use `class_conformsToProtocol()` function for this.

I believe this closes #637, #638, https://groups.google.com/forum/m/#!topic/kiwi-bdd/ZfLol8_Oz8k