### PR TITLE
Make KWHaveValueMatcher use KWGenericMatcher instead of deprecated KiwiGenericMatchingAdditions

### DIFF
--- a/Classes/Matchers/KWGenericMatcher.m
+++ b/Classes/Matchers/KWGenericMatcher.m
@@ -20,7 +20,11 @@
 #pragma mark - Matching
 
 - (BOOL)evaluate {
-    return [KWGenericMatchEvaluator genericMatcher:self.matcher matches:self.subject];
+    if ([KWGenericMatchEvaluator isGenericMatcher:self.matcher]) {
+        return [KWGenericMatchEvaluator genericMatcher:self.matcher matches:self.subject];
+    } else {
+        return [self.matcher isEqual:self.subject];
+    }
 }
 
 - (NSString *)failureMessageForShould {

--- a/Classes/Matchers/KWHaveValueMatcher.m
+++ b/Classes/Matchers/KWHaveValueMatcher.m
@@ -42,7 +42,9 @@
             matched = YES;
             
             if (self.expectedValue) {
-                matched = [self.expectedValue isEqualOrMatches:value];
+                KWGenericMatcher *matcher = [KWGenericMatcher matcherWithSubject:value];
+                [matcher match:self.expectedValue];
+                matched = [matcher evaluate];
             }
         }
     }


### PR DESCRIPTION
Pretty new to the codebase, so would love to get some guidance on if this is the right approach.

This resolves #653.