### PR TITLE
allow running single spec file fast

### DIFF
--- a/Classes/Core/KWSpec.m
+++ b/Classes/Core/KWSpec.m
@@ -49,6 +49,17 @@
     // Only return invocation if the receiver is a concrete spec that has overridden -buildExampleGroups.
     if ([self methodForSelector:buildExampleGroups] == [KWSpec methodForSelector:buildExampleGroups])
         return nil;
+    
+    NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+    NSDictionary *environment = [processInfo environment];
+    NSString *cedarSpecFile = environment[@"CEDAR_SPEC_FILE"];
+    
+    if (cedarSpecFile) {
+        NSString *focusFilePath = [[NSURL URLWithString:cedarSpecFile] path];
+        if (![self file] || ![focusFilePath hasPrefix:[self file]]) {
+            return nil;
+        }
+    }
 
     KWExampleSuite *exampleSuite = [[KWExampleSuiteBuilder sharedExampleSuiteBuilder] buildExampleSuite:^{
         [self buildExampleGroups];


### PR DESCRIPTION
by adding support for CedarShortcuts Xcode plugin

Control-Option-U runs single spec file

Address https://github.com/kiwi-bdd/Kiwi/issues/432 KW_SPEC long load time, 
https://github.com/kiwi-bdd/Kiwi/issues/655 Allow KW_SPEC to specify spec name

This methods excludes test invocations that are not in focus instead of using slow atos as KW_SPEC method does.

Based on https://github.com/paulz/Kiwi-CedarShortcuts pod 

Alternatively Kiwi-CedarShortcuts pod could be used until this request is merged.