### PR TITLE
Rename `bePostedWithObject:andUserInfo:`

### DIFF
--- a/Classes/Matchers/KWNotificationMatcher.h
+++ b/Classes/Matchers/KWNotificationMatcher.h
@@ -14,7 +14,8 @@ typedef void (^PostedNotificationBlock)(NSNotification* note);
 - (void)bePosted;
 - (void)bePostedWithObject:(id)object;
 - (void)bePostedWithUserInfo:(NSDictionary *)userInfo;
-- (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo;
+- (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo DEPRECATED_MSG_ATTRIBUTE("Use -bePostedWithObject:userInfo: method instead.");
+- (void)bePostedWithObject:(id)object userInfo:(NSDictionary *)userInfo;
 - (void)bePostedEvaluatingBlock:(PostedNotificationBlock)block;
 
 @end

--- a/Classes/Matchers/KWNotificationMatcher.m
+++ b/Classes/Matchers/KWNotificationMatcher.m
@@ -20,7 +20,12 @@
 @implementation KWNotificationMatcher
 
 + (NSArray *)matcherStrings {
-    return @[@"bePosted", @"bePostedWithObject:", @"bePostedWithUserInfo:", @"bePostedWithObject:andUserInfo:", @"bePostedEvaluatingBlock:"];
+    return @[@"bePosted",
+             @"bePostedWithObject:",
+             @"bePostedWithUserInfo:",
+             @"bePostedWithObject:andUserInfo:",
+             @"bePostedWithObject:userInfo:",
+             @"bePostedEvaluatingBlock:"];
 }
 
 - (void)addObserver {
@@ -105,6 +110,10 @@
 }
 
 - (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo {
+    [self bePostedWithObject:object userInfo:userInfo];
+}
+
+- (void)bePostedWithObject:(id)object userInfo:(NSDictionary *)userInfo {
     [self addObserver];
     self.expectedObject = object;
     self.expectedUserInfo = userInfo;


### PR DESCRIPTION
As requested in #640, this PR renames `-[KWNotificationMatcher bePostedWithObject:andUserInfo:]` to `-bePostedWithObject:userInfo:`. In order to do so, the following changes were required:

 1. moved existing implementation from `-bePostedWithObject:andUserInfo:` to a new method called `-bePostedWithObject:userInfo:`.
 2. deprecation of the existing `-bePostedWithObject:andUserInfo:` (to avoid breaking changes).

**Note**: The deprecation is done using `DEPRECATED_MSG_ATTRIBUTE()` to include a message referencing the new method in the warning (as done by Apple). But I am happy to change the content of the message or to simply use `DEPRECATED_ATTRIBUTE` as in other parts of the project.