### PR TITLE
Allow Kiwi to correctly run one spec or one test from Xcode

### DIFF
--- a/Classes/Config/KWAllTestsSuite.m
+++ b/Classes/Config/KWAllTestsSuite.m
@@ -36,6 +36,12 @@
     Method testSuiteWithName = class_getClassMethod(self, @selector(testSuiteWithName:));
     Method kiwi_testSuiteWithName = class_getClassMethod(self, @selector(kiwi_testSuiteWithName:));
     method_exchangeImplementations(testSuiteWithName, kiwi_testSuiteWithName);
+    
+    Method kiwi_testSuiteForTestCaseWithName = class_getClassMethod(self, @selector(kiwi_testSuiteForTestCaseWithName:));
+    Method testSuiteForTestCaseWithName = class_getClassMethod(self, @selector(testSuiteForTestCaseWithName:));
+
+    method_exchangeImplementations(kiwi_testSuiteForTestCaseWithName, testSuiteForTestCaseWithName);
+    
 }
 
 + (id)kiwi_testSuiteWithName:(NSString *)aName {
@@ -47,5 +53,60 @@
     }
     return suite;
 }
+
++ (instancetype)kiwi_testSuiteForTestCaseWithName:(NSString *)testCaseName {
+
+    id suite = [self kiwi_testSuiteForTestCaseWithName:testCaseName];
+
+    // If Xcode was able to find valid suite
+    // Then it's probably not Kiwi Test Suite -_-
+    if ([[suite tests] count]) {
+        return suite;
+    }
+
+    // TODO : make suites search to be more efficient
+    // Let's search test suite in the all suites
+    XCTestSuite *allTestsSuite = [XCTestSuite defaultTestSuite];
+
+    // We don't want to search for non-kiwi tests here
+    if (![allTestsSuite isKindOfClass:[_KWAllTestsSuite class]]) {
+        return suite;
+    }
+
+    XCTestSuite * allTestsInBundleSuite = [[allTestsSuite tests] firstObject];
+    NSArray *specs = [allTestsInBundleSuite tests];
+
+    // test case name have format
+    // SpecName/TestName
+    NSArray *specAndTestNameToSearch = [testCaseName componentsSeparatedByString:@"/"];
+    if (![specAndTestNameToSearch count] == 2) {
+        return suite;
+    }
+    NSString *specNameToSearch = specAndTestNameToSearch[0];
+    NSString *testNameToSearch = specAndTestNameToSearch[1];
+
+    for (XCTestSuite *spec in specs) {
+        if (![spec.name isEqualToString:specNameToSearch]) {
+            continue;
+        }
+
+        for (XCTest *test in [spec tests]) {
+            if ([test.name rangeOfString:testNameToSearch].location == NSNotFound) {
+                continue;
+            }
+
+            XCTestSuite *nextSuite = [[XCTestSuite alloc] initWithName:spec.name];
+            [nextSuite addTest:test];
+
+            if ([nextSuite isMemberOfClass:[XCTestSuite class]]) {
+                object_setClass(nextSuite, [_KWAllTestsSuite class]);
+            }
+            return nextSuite;
+        }
+
+    }
+    return suite;
+}
+
 
 @end

--- a/Classes/Core/KWSpec.m
+++ b/Classes/Core/KWSpec.m
@@ -25,31 +25,40 @@
  * In Xcode 7, XCTest behaves like this:
  * First, it tries to find all invocations, and +testInvocations method is called
  * Secondly, KWSpec class is checked again for available tests and for each selector, +testCaseWithSelector: method called
- *   Default XCTest implementation creates it's own NSInvocation, differs from those were created in +testInvocations method
- *   Since this invocation wasn't created by Kiwi, it doesn't have associated kw_example, and incorrect name is returned [[KWSepc (null])
+ * Default XCTest implementation creates it's own NSInvocation, which differs from those were created in +testInvocations method
+ * Since this invocation wasn't created by Kiwi, it doesn't have associated kw_example, and incorrect name is returned [[KWSepc (null])
  *
  */
 + (id)testCaseWithSelector:(SEL)selector {
-    static NSMutableDictionary *testInvocationsPerClass;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        testInvocationsPerClass = [[NSMutableDictionary alloc] init];
-    });
-    NSArray *testInvocations = testInvocationsPerClass[NSStringFromClass(self)];
-    if (!testInvocations) {
-        testInvocations = [self testInvocations];
-        testInvocationsPerClass[NSStringFromClass(self)] = testInvocations;
-    }
-
-    for (NSInvocation *invocation in testInvocations) {
-        if (sel_isEqual(invocation.selector,selector)) {
-            return [[self alloc] initWithInvocation:invocation];
-        }
+    NSInvocation * invocation = [self testInvocationForSelector:selector];
+    if (invocation) {
+        return  [[self alloc] initWithInvocation:invocation];
     }
 
     // Falling back to default implementation, if we didn't found invocation for this selector
     return [super testCaseWithSelector:selector];
 }
+
+static char * _cachedTestInvocationsKey = "cachedInvocationsKey";
+
++ (NSInvocation *)testInvocationForSelector:(SEL)selector {
+    NSDictionary *cachedInvocationsPerSelector = objc_getAssociatedObject(self, _cachedTestInvocationsKey);
+
+    if (!cachedInvocationsPerSelector) {
+        NSMutableDictionary *cachedTestInvocations = [NSMutableDictionary dictionary];
+        for (NSInvocation *testInvocation in [self testInvocations]) {
+            NSString *selectorString = NSStringFromSelector(testInvocation.selector);
+            cachedTestInvocations[selectorString] = testInvocation;
+        }
+
+        objc_setAssociatedObject(self, _cachedTestInvocationsKey, cachedTestInvocations, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        cachedInvocationsPerSelector = cachedTestInvocations;
+    }
+
+    NSString *selectorString = NSStringFromSelector(selector);
+    return cachedInvocationsPerSelector[selectorString];
+}
+
 
 /* Methods are only implemented by sub-classes */
 

--- a/Classes/Core/KWSpec.m
+++ b/Classes/Core/KWSpec.m
@@ -25,40 +25,31 @@
  * In Xcode 7, XCTest behaves like this:
  * First, it tries to find all invocations, and +testInvocations method is called
  * Secondly, KWSpec class is checked again for available tests and for each selector, +testCaseWithSelector: method called
- * Default XCTest implementation creates it's own NSInvocation, which differs from those were created in +testInvocations method
- * Since this invocation wasn't created by Kiwi, it doesn't have associated kw_example, and incorrect name is returned [[KWSepc (null])
+ *   Default XCTest implementation creates it's own NSInvocation, differs from those were created in +testInvocations method
+ *   Since this invocation wasn't created by Kiwi, it doesn't have associated kw_example, and incorrect name is returned [[KWSepc (null])
  *
  */
 + (id)testCaseWithSelector:(SEL)selector {
-    NSInvocation * invocation = [self testInvocationForSelector:selector];
-    if (invocation) {
-        return  [[self alloc] initWithInvocation:invocation];
+    static NSMutableDictionary *testInvocationsPerClass;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        testInvocationsPerClass = [[NSMutableDictionary alloc] init];
+    });
+    NSArray *testInvocations = testInvocationsPerClass[NSStringFromClass(self)];
+    if (!testInvocations) {
+        testInvocations = [self testInvocations];
+        testInvocationsPerClass[NSStringFromClass(self)] = testInvocations;
+    }
+
+    for (NSInvocation *invocation in testInvocations) {
+        if (sel_isEqual(invocation.selector,selector)) {
+            return [[self alloc] initWithInvocation:invocation];
+        }
     }
 
     // Falling back to default implementation, if we didn't found invocation for this selector
     return [super testCaseWithSelector:selector];
 }
-
-static char * _cachedTestInvocationsKey = "cachedInvocationsKey";
-
-+ (NSInvocation *)testInvocationForSelector:(SEL)selector {
-    NSDictionary *cachedInvocationsPerSelector = objc_getAssociatedObject(self, _cachedTestInvocationsKey);
-
-    if (!cachedInvocationsPerSelector) {
-        NSMutableDictionary *cachedTestInvocations = [NSMutableDictionary dictionary];
-        for (NSInvocation *testInvocation in [self testInvocations]) {
-            NSString *selectorString = NSStringFromSelector(testInvocation.selector);
-            cachedTestInvocations[selectorString] = testInvocation;
-        }
-
-        objc_setAssociatedObject(self, _cachedTestInvocationsKey, cachedTestInvocations, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        cachedInvocationsPerSelector = cachedTestInvocations;
-    }
-
-    NSString *selectorString = NSStringFromSelector(selector);
-    return cachedInvocationsPerSelector[selectorString];
-}
-
 
 /* Methods are only implemented by sub-classes */
 

--- a/Classes/Matchers/KWNotificationMatcher.h
+++ b/Classes/Matchers/KWNotificationMatcher.h
@@ -14,7 +14,8 @@ typedef void (^PostedNotificationBlock)(NSNotification* note);
 - (void)bePosted;
 - (void)bePostedWithObject:(id)object;
 - (void)bePostedWithUserInfo:(NSDictionary *)userInfo;
-- (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo;
+- (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo DEPRECATED_MSG_ATTRIBUTE("Use -bePostedWithObject:userInfo: method instead.");
+- (void)bePostedWithObject:(id)object userInfo:(NSDictionary *)userInfo;
 - (void)bePostedEvaluatingBlock:(PostedNotificationBlock)block;
 
 @end

--- a/Classes/Matchers/KWNotificationMatcher.m
+++ b/Classes/Matchers/KWNotificationMatcher.m
@@ -20,7 +20,12 @@
 @implementation KWNotificationMatcher
 
 + (NSArray *)matcherStrings {
-    return @[@"bePosted", @"bePostedWithObject:", @"bePostedWithUserInfo:", @"bePostedWithObject:andUserInfo:", @"bePostedEvaluatingBlock:"];
+    return @[@"bePosted",
+             @"bePostedWithObject:",
+             @"bePostedWithUserInfo:",
+             @"bePostedWithObject:andUserInfo:",
+             @"bePostedWithObject:userInfo:",
+             @"bePostedEvaluatingBlock:"];
 }
 
 - (void)addObserver {
@@ -105,6 +110,10 @@
 }
 
 - (void)bePostedWithObject:(id)object andUserInfo:(NSDictionary *)userInfo {
+    [self bePostedWithObject:object userInfo:userInfo];
+}
+
+- (void)bePostedWithObject:(id)object userInfo:(NSDictionary *)userInfo {
     [self addObserver];
     self.expectedObject = object;
     self.expectedUserInfo = userInfo;


### PR DESCRIPTION
This one fixes  #645 

This PR is actually highly dependent on the PR #648
And actual changed are actually only in the 48f529a commit

So what's happening here:
When Xcode runs _all tests_ - it's calling `[XCTestSuite defaultTestSuite]` which then calls `[XCTestSuite testSuiteWithName:]` with `All Tests` parameter
So that part his works fine

When Xcode runs _one test_ or _one suite_, it's using `testSuiteForTestCaseWithName:` method, and fails to find actual test.

In this commit we're checking if testSuite was found, and if it wasn't trying to find it from all test suites
