### PR TITLE
Releasing Verifiers after KWExample run

### DIFF
--- a/Classes/Core/KWExample.m
+++ b/Classes/Core/KWExample.m
@@ -117,6 +117,12 @@
   return verifier;
 }
 
+#pragma mark - Clear Verifiers
+
+- (void)clearVerifiers {
+    [self.verifiers removeAllObjects];
+}
+
 #pragma mark - Running examples
 
 - (void)runWithDelegate:(XCTestCase<KWExampleDelegate> *)delegate {
@@ -124,6 +130,7 @@
     [self.matcherFactory registerMatcherClassesWithNamespacePrefix:@"KW"];
     [[KWExampleSuiteBuilder sharedExampleSuiteBuilder] setCurrentExample:self];
     [self.exampleNode acceptExampleNodeVisitor:self];
+    [self clearVerifiers];
 }
 
 #pragma mark - Reporting failure


### PR DESCRIPTION
- Releases retained resources held by the verifiers
- Avoids issues with objects in memory which have NSNotificationCenter subscriptions