### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: objective-c
 osx_image: xcode7.3
-before_install:
-  - gem install xcpretty # this will go away soon when Travis installs xcpretty
-  - gem install cocoapods # latest version of cocoapods
 script: make ci
-

--- a/Classes/Config/KWAllTestsSuite.m
+++ b/Classes/Config/KWAllTestsSuite.m
@@ -40,7 +40,7 @@
 
 + (id)kiwi_testSuiteWithName:(NSString *)aName {
     id suite = [self kiwi_testSuiteWithName:aName];
-    if ([aName isEqualToString:@"All tests"]) {
+    if ([aName isEqualToString:@"All tests"] || [aName isEqualToString:@"KiwiTests.xctest"]) {
         if ([suite isMemberOfClass:[XCTestSuite class]]) {
             object_setClass(suite, [_KWAllTestsSuite class]);
         }

--- a/Classes/Config/KWAllTestsSuite.m
+++ b/Classes/Config/KWAllTestsSuite.m
@@ -33,9 +33,12 @@
 @implementation XCTestSuite (KWConfiguration)
 
 + (void)load {
-    Method testSuiteWithName = class_getClassMethod(self, @selector(testSuiteWithName:));
-    Method kiwi_testSuiteWithName = class_getClassMethod(self, @selector(kiwi_testSuiteWithName:));
-    method_exchangeImplementations(testSuiteWithName, kiwi_testSuiteWithName);
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Method testSuiteWithName = class_getClassMethod(self, @selector(testSuiteWithName:));
+        Method kiwi_testSuiteWithName = class_getClassMethod(self, @selector(kiwi_testSuiteWithName:));
+        method_exchangeImplementations(testSuiteWithName, kiwi_testSuiteWithName);
+    });
 }
 
 + (id)kiwi_testSuiteWithName:(NSString *)aName {

--- a/Classes/Config/KWAllTestsSuite.m
+++ b/Classes/Config/KWAllTestsSuite.m
@@ -40,7 +40,7 @@
 
 + (id)kiwi_testSuiteWithName:(NSString *)aName {
     id suite = [self kiwi_testSuiteWithName:aName];
-    if ([aName isEqualToString:@"All tests"] || [aName isEqualToString:@"KiwiTests.xctest"]) {
+    if ([aName isEqualToString:@"All tests"] || [aName hasSuffix:@".xctest"]) {
         if ([suite isMemberOfClass:[XCTestSuite class]]) {
             object_setClass(suite, [_KWAllTestsSuite class]);
         }


### PR DESCRIPTION
This PR fixes the bug that was preventing all new CI builds to fail.

### Problem:

Builds in Travis CI fail although all tests are passing:
```
Executed 376 tests, with 0 failures (0 unexpected) in 2.300 (3.782) seconds

ruby test_suite_configuration.rb xcodebuild.log
error: expected xcodebuild.log to include beforeAllSpecs and afterAllSpecs in its output
make: *** [test-iphone32] Error 1

The command "make ci" exited with 2.
```

This is due to the check done in [test_suite_configuration.rb](https://github.com/kiwi-bdd/Kiwi/blob/9429e0a439ea2dfc8de9d4a2cd9ff449bcf456d8/test_suite_configuration.rb#L12), which expects Xcode's logs to contain mentions to `beforeAllSpec` and `afterAllSpec`. Its purpose is to ensure these [two](https://github.com/kiwi-bdd/Kiwi/blob/9429e0a439ea2dfc8de9d4a2cd9ff449bcf456d8/Tests/Config.m#L7) [lines](https://github.com/kiwi-bdd/Kiwi/blob/9429e0a439ea2dfc8de9d4a2cd9ff449bcf456d8/Tests/Config.m#L13) run and therefore are properly tested. Unfortunately, this code is no longer run.

### Solution:

After investigating the issue, apparently this is due to the swizzling done in [KWAllTestsSuite.m](https://github.com/kiwi-bdd/Kiwi/blob/9429e0a439ea2dfc8de9d4a2cd9ff449bcf456d8/Classes/Config/KWAllTestsSuite.m) not being run, which means that the `XCTestSuite` is never replaced with Kiwi's custom `_KWAllTestsSuite`. Therefore the `beforeAll` and `afterAll` do not run.

The cause behind it is that the method [`kiwi_testSuiteWithName`](https://github.com/kiwi-bdd/Kiwi/blob/9429e0a439ea2dfc8de9d4a2cd9ff449bcf456d8/Classes/Config/KWAllTestsSuite.m#L41) is no longer called with `"All tests"` as an argument, which prevents the swizzling from happening (see [this `if` statement](https://github.com/kiwi-bdd/Kiwi/blob/9429e0a439ea2dfc8de9d4a2cd9ff449bcf456d8/Classes/Config/KWAllTestsSuite.m#L43)). Instead, now it receives the tests target name as the suite name (e.g. `"YourTestsTarget.xctest"`). This must be a change introduced in XCTest that we were not aware of.

Therefore, the proposed solution is to allow the swizzling to run also if the suite name contains the `".xctest"` prefix, meaning it is an `XCTestSuite`.

For compatibility, I am leaving the `"All tests"` check. But my feeling is that we could probably remove it.