### PR TITLE
Rename any() macros to kw_any()

### DIFF
--- a/Classes/Core/KiwiMacros.h
+++ b/Classes/Core/KiwiMacros.h
@@ -62,7 +62,7 @@
 #define fail(message, ...) [[[KWExampleSuiteBuilder sharedExampleSuiteBuilder] currentExample] reportFailure:[KWFailure failureWithCallSite:KW_THIS_CALLSITE format:message, ##__VA_ARGS__]]
 
 // used for message patterns to allow matching any value
-#define any() [KWAny any]
+#define kw_any() [KWAny any]
 #endif
 
 // If a gcc compatible compiler is available, use the statement and

--- a/Tests/KWMockTest.m
+++ b/Tests/KWMockTest.m
@@ -112,9 +112,9 @@
 
 - (void)testItShouldStubWithASelectorReturnValueAndAnyArguments {
     id mock = [Cruiser nullMock];
-    [mock stub:@selector(energyLevelInWarpCore:) andReturn:theValue(30.0f) withArguments:any()];
-    XCTAssertEqual([mock energyLevelInWarpCore:3], 30.0f, @"expected method with any() arguments to be stubbed");
-    XCTAssertEqual([mock energyLevelInWarpCore:2], 30.0f, @"expected method with any() arguments to be stubbed");
+    [mock stub:@selector(energyLevelInWarpCore:) andReturn:theValue(30.0f) withArguments:kw_any()];
+    XCTAssertEqual([mock energyLevelInWarpCore:3], 30.0f, @"expected method with kw_any() arguments to be stubbed");
+    XCTAssertEqual([mock energyLevelInWarpCore:2], 30.0f, @"expected method with kw_any() arguments to be stubbed");
 }
 
 - (void)testItShouldStubWithAMessage {

--- a/Tests/KWRealObjectStubTest.m
+++ b/Tests/KWRealObjectStubTest.m
@@ -49,7 +49,7 @@
 - (void)testItShouldStubInstanceMethodsReturningObjectsWithAnyArguments {
     Cruiser *cruiser = [Cruiser cruiserWithCallsign:@"Galactica"];
     Fighter *fighter = [Fighter fighterWithCallsign:@"Viper 1"];
-    [cruiser stub:@selector(fighterWithCallsign:) andReturn:fighter withArguments:any()];
+    [cruiser stub:@selector(fighterWithCallsign:) andReturn:fighter withArguments:kw_any()];
     XCTAssertEqual(fighter, [cruiser fighterWithCallsign:@"Foo"], @"expected method to be stubbed");
 }
 


### PR DESCRIPTION
This PR is just a rebased version of #701 to pick the changes introduced in #703.

It closes #698.
  