### PR TITLE
Removes deprecated stubs

### DIFF
--- a/Classes/Stubbing/NSObject+KiwiStubAdditions.h
+++ b/Classes/Stubbing/NSObject+KiwiStubAdditions.h
@@ -29,10 +29,6 @@
 + (void)stub:(SEL)aSelector andReturn:(id)aValue withArguments:(id)firstArgument, ...;
 + (void)stub:(SEL)aSelector andReturn:(id)aValue times:(NSNumber *)times afterThatReturn:(id)aSecondValue;
 
-- (id)stub DEPRECATED_ATTRIBUTE;
-- (id)stubAndReturn:(id)aValue DEPRECATED_ATTRIBUTE;
-- (id)stubAndReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue DEPRECATED_ATTRIBUTE;
-
 // These methods will become private
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue;
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue overrideExisting:(BOOL)overrideExisting;

--- a/Classes/Stubbing/NSObject+KiwiStubAdditions.m
+++ b/Classes/Stubbing/NSObject+KiwiStubAdditions.m
@@ -113,20 +113,6 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     [self stubMessagePattern:messagePattern andReturn:aValue times:times afterThatReturn:aSecondValue];
 }
 
-- (id)stub {
-    return [KWInvocationCapturer invocationCapturerWithDelegate:self];
-}
-
-- (id)stubAndReturn:(id)aValue {
-    NSDictionary *userInfo = @{StubValueKey: aValue};
-    return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
-}
-
-- (id)stubAndReturn:(id)aValue times:(id)times afterThatReturn:(id)aSecondValue {
-    NSDictionary *userInfo = @{StubValueKey: aValue, ChangeStubValueAfterTimesKey: times, StubSecondValueKey: aSecondValue};
-    return [KWInvocationCapturer invocationCapturerWithDelegate:self userInfo:userInfo];
-}
-
 - (void)stubMessagePattern:(KWMessagePattern *)aMessagePattern andReturn:(id)aValue {
     [self stubMessagePattern:aMessagePattern andReturn:aValue overrideExisting:YES];
 }


### PR DESCRIPTION
This PR removes the deprecated methods in NSObject+KiwiStubAdditions.h/m.
I supposed they are not needed anymore since they were deprecated in 2014. It will also avoid to have compiler flag to removes those warnings.

Note: hopefully this one is not a duplicate🤞 