### PR TITLE
allow the use of notification matcher with async verifier

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v8.0.5"
+github "Quick/Nimble" "v7.0.3"
 github "specta/expecta" "v1.0.6"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.0.3"
+github "Quick/Nimble" "v8.0.5"
 github "specta/expecta" "v1.0.6"

--- a/Classes/Matchers/KWNotificationMatcher.h
+++ b/Classes/Matchers/KWNotificationMatcher.h
@@ -18,4 +18,6 @@ typedef void (^PostedNotificationBlock)(NSNotification* note);
 - (void)bePostedWithObject:(id)object userInfo:(NSDictionary *)userInfo;
 - (void)bePostedEvaluatingBlock:(PostedNotificationBlock)block;
 
+#pragma mark - KWMatching
+@property (nonatomic, assign) BOOL willEvaluateMultipleTimes;
 @end

--- a/Classes/Matchers/KWNotificationMatcher.m
+++ b/Classes/Matchers/KWNotificationMatcher.m
@@ -45,14 +45,30 @@
                                         if (self.evaluationBlock) {
                                             self.evaluationBlock(note);
                                         }
+                                        if (self.didReceiveNotification) {
+                                            [self removeObserver];
+                                        }
                                     }];
+}
+
+- (void)removeObserver {
+    if (self.observer) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self.observer];
+        self.observer = nil;
+    }
 }
 
 #pragma mark - Matching
 
 - (BOOL)evaluate {
-    [[NSNotificationCenter defaultCenter] removeObserver:self.observer];
+    if (!self.willEvaluateMultipleTimes) {
+        [self removeObserver];
+    }
     return self.didReceiveNotification;
+}
+
+- (void)dealloc {
+    [self removeObserver];
 }
 
 - (BOOL)shouldBeEvaluatedAtEndOfExample {

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -249,6 +249,8 @@
 		4AE030CA1AEB4DCF00556381 /* NSObject+KiwiSpyAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F982CD916A802920030A0B1 /* NSObject+KiwiSpyAdditions.m */; };
 		4B9314A523D0E83C007A295C /* KWNotificationMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */; };
 		4B9314A623D0E83C007A295C /* KWNotificationMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */; };
+		4B9314A823D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B9314A723D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m */; };
+		4B9314A923D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B9314A723D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m */; };
 		50ACAF651BBA28D000F29B0F /* DoNotUseMe.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */; };
 		50ACAF661BBA28D000F29B0F /* DoNotUseMe.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */; };
 		CE0736B41B8577140023EBEA /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0736B31B8577140023EBEA /* Expecta.framework */; };
@@ -591,6 +593,7 @@
 		4AE33458195820DC00CDE895 /* KWMessagePattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWMessagePattern.h; sourceTree = "<group>"; };
 		4AE33459195820DC00CDE895 /* KWMessagePattern.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWMessagePattern.m; sourceTree = "<group>"; };
 		4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWNotificationMatcherTest.m; sourceTree = "<group>"; };
+		4B9314A723D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWNotificationMatcherFunctionalTests.m; sourceTree = "<group>"; };
 		4BA52D0015487F0C00FC957B /* KWCaptureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWCaptureTest.m; sourceTree = "<group>"; };
 		4E3C5DB01716C34900835B62 /* KWRegularExpressionPatternMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWRegularExpressionPatternMatcher.h; sourceTree = "<group>"; };
 		4E3C5DB11716C34900835B62 /* KWRegularExpressionPatternMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWRegularExpressionPatternMatcher.m; sourceTree = "<group>"; };
@@ -1225,6 +1228,7 @@
 				CE0736B71B8577490023EBEA /* KWExpectaTests.m */,
 				89F9CB7B16B1C2C400E87D34 /* KWFunctionalTests.m */,
 				4A4AA324195B7C4E00423CD6 /* KWMessagePatternFunctionalTests.m */,
+				4B9314A723D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m */,
 				CE39E6171B857CE000736C33 /* KWObjCNimbleTests.m */,
 				CE7EFF9B1B847AD700FFE6D6 /* KWObjCXCTestAssertionTests.m */,
 				CE39E61A1B857DE300736C33 /* KWSwiftNimbleTests.swift */,
@@ -1881,6 +1885,7 @@
 				4AE030B11AEB494400556381 /* Carrier.m in Sources */,
 				4AE030B21AEB494400556381 /* Cruiser.m in Sources */,
 				4AE030B31AEB494400556381 /* Engine.m in Sources */,
+				4B9314A923D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m in Sources */,
 				CE7EFF9D1B847AD700FFE6D6 /* KWObjCXCTestAssertionTests.m in Sources */,
 				4AE030B41AEB494400556381 /* Fighter.m in Sources */,
 				4AE030B51AEB494400556381 /* Galaxy.m in Sources */,
@@ -2047,6 +2052,7 @@
 				CE87C5171AF1994200310C07 /* Cruiser.m in Sources */,
 				CE87C5181AF1994200310C07 /* Engine.m in Sources */,
 				CE87C5191AF1994200310C07 /* Fighter.m in Sources */,
+				4B9314A823D0F4C6007A295C /* KWNotificationMatcherFunctionalTests.m in Sources */,
 				CE7EFF9C1B847AD700FFE6D6 /* KWObjCXCTestAssertionTests.m in Sources */,
 				CE87C51A1AF1994200310C07 /* Galaxy.m in Sources */,
 				CE87C51D1AF1994200310C07 /* Robot.m in Sources */,

--- a/Kiwi.xcodeproj/project.pbxproj
+++ b/Kiwi.xcodeproj/project.pbxproj
@@ -247,6 +247,8 @@
 		4AE030C81AEB494400556381 /* KWValueTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C6FD2311782A290068BBC8 /* KWValueTest.m */; };
 		4AE030C91AEB494400556381 /* NSNumber_KiwiAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C69F7190CA6EE002C4DC0 /* NSNumber_KiwiAdditionsTests.m */; };
 		4AE030CA1AEB4DCF00556381 /* NSObject+KiwiSpyAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F982CD916A802920030A0B1 /* NSObject+KiwiSpyAdditions.m */; };
+		4B9314A523D0E83C007A295C /* KWNotificationMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */; };
+		4B9314A623D0E83C007A295C /* KWNotificationMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */; };
 		50ACAF651BBA28D000F29B0F /* DoNotUseMe.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */; };
 		50ACAF661BBA28D000F29B0F /* DoNotUseMe.m in Sources */ = {isa = PBXBuildFile; fileRef = 50ACAF641BBA28D000F29B0F /* DoNotUseMe.m */; };
 		CE0736B41B8577140023EBEA /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0736B31B8577140023EBEA /* Expecta.framework */; };
@@ -588,6 +590,7 @@
 		4AE02FD81AEB46D000556381 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AE33458195820DC00CDE895 /* KWMessagePattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWMessagePattern.h; sourceTree = "<group>"; };
 		4AE33459195820DC00CDE895 /* KWMessagePattern.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWMessagePattern.m; sourceTree = "<group>"; };
+		4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWNotificationMatcherTest.m; sourceTree = "<group>"; };
 		4BA52D0015487F0C00FC957B /* KWCaptureTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWCaptureTest.m; sourceTree = "<group>"; };
 		4E3C5DB01716C34900835B62 /* KWRegularExpressionPatternMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWRegularExpressionPatternMatcher.h; sourceTree = "<group>"; };
 		4E3C5DB11716C34900835B62 /* KWRegularExpressionPatternMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWRegularExpressionPatternMatcher.m; sourceTree = "<group>"; };
@@ -1343,6 +1346,7 @@
 				F553B29D11755A00004FCA2E /* KWInequalityMatcherTest.m */,
 				F5C36E91115C9F0700425FDA /* KWReceiveMatcherTest.m */,
 				4E3C5DB71716C68000835B62 /* KWRegularExpressionPatternMatcherTest.m */,
+				4B9314A423D0E83C007A295C /* KWNotificationMatcherTest.m */,
 				F553B6641175D48C004FCA2E /* KWRespondToSelectorMatcherTest.m */,
 				A385CAE713AA7EA200DCA951 /* KWUserDefinedMatcherTest.m */,
 				C931D36D18AB2DEB005BC184 /* KWBeZeroMatcherTest.m */,
@@ -1844,6 +1848,7 @@
 				4AE030951AEB494400556381 /* KWBeTrueMatcherTest.m in Sources */,
 				4AE030961AEB494400556381 /* KWBeWithinMatcherTest.m in Sources */,
 				4AE030971AEB494400556381 /* KWBlockRaiseMatcherTest.m in Sources */,
+				4B9314A623D0E83C007A295C /* KWNotificationMatcherTest.m in Sources */,
 				4AE030981AEB494400556381 /* KWChangeMatcherTest.m in Sources */,
 				4AE030991AEB494400556381 /* KWConformToProtocolMatcherTest.m in Sources */,
 				CE39E61C1B857DE300736C33 /* KWSwiftNimbleTests.swift in Sources */,
@@ -2009,6 +2014,7 @@
 				CE87C4FB1AF1994100310C07 /* KWBeWithinMatcherTest.m in Sources */,
 				CE87C4FC1AF1994100310C07 /* KWBlockRaiseMatcherTest.m in Sources */,
 				CE87C4FD1AF1994100310C07 /* KWChangeMatcherTest.m in Sources */,
+				4B9314A523D0E83C007A295C /* KWNotificationMatcherTest.m in Sources */,
 				CE87C4FE1AF1994100310C07 /* KWConformToProtocolMatcherTest.m in Sources */,
 				CE87C4FF1AF1994100310C07 /* KWContainMatcherTest.m in Sources */,
 				CE39E61B1B857DE300736C33 /* KWSwiftNimbleTests.swift in Sources */,

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-OSX.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-OSX.xcscheme
@@ -26,7 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,6 +38,15 @@
             ReferencedContainer = "container:Kiwi.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AE02FBC1AEB45EB00556381"
+            BuildableName = "Kiwi.framework"
+            BlueprintName = "Kiwi-OSX"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-OSX.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-OSX.xcscheme
@@ -26,8 +26,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AE02FBC1AEB45EB00556381"
+            BuildableName = "Kiwi.framework"
+            BlueprintName = "Kiwi-OSX"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,23 +48,11 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4AE02FBC1AEB45EB00556381"
-            BuildableName = "Kiwi.framework"
-            BlueprintName = "Kiwi-OSX"
-            ReferencedContainer = "container:Kiwi.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -72,8 +68,6 @@
             ReferencedContainer = "container:Kiwi.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-iOS.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-iOS.xcscheme
@@ -26,8 +26,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE87C4221AF194E900310C07"
+            BuildableName = "Kiwi.framework"
+            BlueprintName = "Kiwi-iOS"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,23 +48,11 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CE87C4221AF194E900310C07"
-            BuildableName = "Kiwi.framework"
-            BlueprintName = "Kiwi-iOS"
-            ReferencedContainer = "container:Kiwi.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -72,8 +68,6 @@
             ReferencedContainer = "container:Kiwi.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-iOS.xcscheme
+++ b/Kiwi.xcodeproj/xcshareddata/xcschemes/Kiwi-iOS.xcscheme
@@ -26,7 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,6 +38,15 @@
             ReferencedContainer = "container:Kiwi.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE87C4221AF194E900310C07"
+            BuildableName = "Kiwi.framework"
+            BlueprintName = "Kiwi-iOS"
+            ReferencedContainer = "container:Kiwi.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tests/KWNotificationMatcherFunctionalTests.m
+++ b/Tests/KWNotificationMatcherFunctionalTests.m
@@ -54,6 +54,22 @@ describe(@"KWNotificationMatcher", ^{
             [[theValue(blockWasEvaluated) should] beTrue];
         });
     });
+
+    context(@"asynchronous notification", ^{
+        void (^postDelayedNotification)(void) = ^{
+            [center performSelector:@selector(postNotificationName:object:) withObject:@"My Notification" afterDelay:0];
+        };
+
+        it(@"should not match syncronous expectation", ^{
+            [[@"My Notification" shouldNot] bePosted];
+            postDelayedNotification();
+        });
+
+        it(@"should match eventually", ^{
+            [[@"My Notification" shouldEventually] bePosted];
+            postDelayedNotification();
+        });
+    });
 });
 
 SPEC_END

--- a/Tests/KWNotificationMatcherFunctionalTests.m
+++ b/Tests/KWNotificationMatcherFunctionalTests.m
@@ -1,0 +1,59 @@
+#import <Kiwi/Kiwi.h>
+#import "KiwiTestConfiguration.h"
+#import "TestClasses.h"
+
+SPEC_BEGIN(KWNotificationMatcherFunctionalTests)
+
+describe(@"KWNotificationMatcher", ^{
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+
+    context(@"bePosted", ^{
+        it(@"should match posted notification", ^{
+            [[@"My Notification" should] bePosted];
+            [center postNotificationName:@"My Notification" object:nil];
+        });
+    });
+
+    context(@"bePostedWithObject", ^{
+        it(@"should match object", ^{
+            NSObject *object = [NSObject new];
+            [[@"My Notification" should] bePostedWithObject:object];
+            [[@"My Notification" shouldNot] bePostedWithObject:@"not matching object"];
+            [center postNotificationName:@"My Notification" object:object];
+        });
+    });
+
+    context(@"bePostedWithUserInfo", ^{
+        it(@"should match user info", ^{
+            [[@"My Notification" should] bePostedWithUserInfo:@{@"some key":@"some value"}];
+            [[@"My Notification" shouldNot] bePostedWithUserInfo:@{@"some key":@"not matching value"}];
+            [center postNotificationName:@"My Notification" object:nil userInfo:@{@"some key":@"some value"}];
+        });
+    });
+
+    context(@"bePostedWithObject:userInfo:", ^{
+        it(@"should match both object and user info", ^{
+            NSObject *object = [NSObject new];
+            [[@"My Notification" should] bePostedWithObject:object userInfo:@{@"some key":@"some value"}];
+            [[@"My Notification" shouldNot] bePostedWithObject:object userInfo:@{@"some key":@"not matching value"}];
+            [[@"My Notification" shouldNot] bePostedWithObject:[NSObject new] userInfo:@{@"some key":@"some value"}];
+            [center postNotificationName:@"My Notification" object:object userInfo:@{@"some key":@"some value"}];
+
+        });
+    });
+
+    context(@"bePostedEvaluatingBlock", ^{
+        it(@"should match and evaluate block", ^{
+            __block BOOL blockWasEvaluated = NO;
+            [[@"My Notification" should] bePostedEvaluatingBlock:^(NSNotification *note) {
+                [[note shouldNot] beNil];
+                [[note.name should] equal:@"My Notification"];
+                blockWasEvaluated = TRUE;
+            }];
+            [center postNotificationName:@"My Notification" object:nil];
+            [[theValue(blockWasEvaluated) should] beTrue];
+        });
+    });
+});
+
+SPEC_END

--- a/Tests/KWNotificationMatcherTest.m
+++ b/Tests/KWNotificationMatcherTest.m
@@ -10,7 +10,7 @@
 
 #if KW_TESTS_ENABLED
 
-@interface KWNotificatoinMatcherTest : SenTestCase
+@interface KWNotificatoinMatcherTest : XCTestCase
 
 @end
 
@@ -18,8 +18,13 @@
 
 - (void)testItShouldHaveTheRightMatcherStrings {
     NSArray *matcherStrings = [KWNotificationMatcher matcherStrings];
-    NSArray *expectedStrings = @[@"bePosted", @"bePostedWithObject:", @"bePostedWithUserInfo:", @"bePostedWithObject:andUserInfo:", @"bePostedEvaluatingBlock:"];
-    STAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
+    NSArray *expectedStrings = @[@"bePosted",
+                                 @"bePostedWithObject:",
+                                 @"bePostedWithUserInfo:",
+                                 @"bePostedWithObject:andUserInfo:",
+                                 @"bePostedWithObject:userInfo:",
+                                 @"bePostedEvaluatingBlock:"];
+    XCTAssertEqualObjects([matcherStrings sortedArrayUsingSelector:@selector(compare:)],
                          [expectedStrings sortedArrayUsingSelector:@selector(compare:)],
                          @"expected specific matcher strings");
 }
@@ -27,96 +32,96 @@
 - (void)testEachMatcherStringIsANameOfAMatchingMethod {
     NSArray *matcherStrings = [KWNotificationMatcher matcherStrings];
     for (NSString *string in matcherStrings) {
-        STAssertTrue([KWNotificationMatcher instancesRespondToSelector:NSSelectorFromString(string)], @"expect to find an instance method: %@", string);
+        XCTAssertTrue([KWNotificationMatcher instancesRespondToSelector:NSSelectorFromString(string)], @"expect to find an instance method: %@", string);
     }
 }
 
 - (void)testItShouldMatchPostedNotificationWithAnyObject {
-    id object = [[[NSObject alloc] init] autorelease];
+    id object = [NSObject new];
     id subject = @"MyNotification";
-    id matcher = [KWNotificationMatcher matcherWithSubject:subject];
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
     [matcher bePosted];
     [[NSNotificationCenter defaultCenter] postNotificationName:subject object:object];
-    STAssertTrue([matcher evaluate], @"expected positive match");
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldMatchPostedNotificationWithMatchingObject {
-    id object = [[[NSObject alloc] init] autorelease];
+    id object = [NSObject new];
     id subject = @"MyNotification";
-    id matcher = [KWNotificationMatcher matcherWithSubject:subject];
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
     [matcher bePostedWithObject:object];
     [[NSNotificationCenter defaultCenter] postNotificationName:subject object:object];
-    STAssertTrue([matcher evaluate], @"expected positive match");
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldMatchPostedNotificationWithMatchingUserInfo {
-    id object = [[[NSObject alloc] init] autorelease];
+    id object = [NSObject new];
     id subject = @"MyNotification";
-    id matcher = [KWNotificationMatcher matcherWithSubject:subject];
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
     [matcher bePostedWithUserInfo:@{@"a":@"b", @1:@2}];
     [[NSNotificationCenter defaultCenter] postNotificationName:subject object:object userInfo:@{@"a":@"b", @1:@2}];
-    STAssertTrue([matcher evaluate], @"expected positive match");
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldMatchPostedNotificationWithMatchingObjectAndUserInfo {
-    id object = [[[NSObject alloc] init] autorelease];
+    id object = [NSObject new];
     id subject = @"MyNotification";
-    id matcher = [KWNotificationMatcher matcherWithSubject:subject];
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
     [matcher bePostedWithObject:object andUserInfo:@{@"a":@"b", @1:@2}];
     [[NSNotificationCenter defaultCenter] postNotificationName:subject object:object userInfo:@{@"a":@"b", @1:@2}];
-    STAssertTrue([matcher evaluate], @"expected positive match");
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldMatchPostedNotificationEvaluatingBlock {
-    id object = [[[NSObject alloc] init] autorelease];
+    id object = [NSObject new];
     id subject = @"MyNotification";
-    id matcher = [KWNotificationMatcher matcherWithSubject:subject];
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
     [matcher bePostedEvaluatingBlock:^(NSNotification *note) {
-        STAssertEquals(subject, [note name], @"expected notification name");
-        STAssertEquals(object, [note object], @"expected notification object");
-        STAssertNotNil([note userInfo][@"PATH"], @"expected notification user info to include environment PATH");
+        XCTAssertEqual(subject, [note name], @"expected notification name");
+        XCTAssertEqual(object, [note object], @"expected notification object");
+        XCTAssertNotNil([note userInfo][@"PATH"], @"expected notification user info to include environment PATH");
     }];
     [[NSNotificationCenter defaultCenter] postNotificationName:subject object:object userInfo:[[NSProcessInfo processInfo] environment]];
-    STAssertTrue([matcher evaluate], @"expected positive match");
+    XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
 
 - (void)testItShouldNotMatchWhenNothingHaveBeenPosted {
     id subject = @"MyNotification";
-    id matcher = [KWNotificationMatcher matcherWithSubject:subject];
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
     [matcher bePosted];
-    STAssertFalse([matcher evaluate], @"expected negative match");
+    XCTAssertFalse([matcher evaluate], @"expected negative match");
 }
 
 - (void)testItShouldHaveHumanReadableDescription {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePosted];
-    STAssertEqualObjects(@"NSPortDidBecomeInvalidNotification be posted", [matcher description], @"description should match");
+    XCTAssertEqualObjects(@"NSPortDidBecomeInvalidNotification be posted", [matcher description], @"description should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShould {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePosted];
-    STAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" notification", @"failure message should match");
+    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" notification", @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithObject {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePostedWithObject:@"sender"];
-    STAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
+    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
                          "notification with object: sender", @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithUserInfo {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePostedWithUserInfo:@{@"message":@"text"}];
-    STAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
+    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
                          "notification with user info: {\n    message = text;\n}", @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithObjectAndUserInfo {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePostedWithObject:@"sender" andUserInfo:@{@"message":@"text"}];
-    STAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
+    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
                          "notification with object: sender and user info: {\n    message = text;\n}", @"failure message should match");
 }
 
@@ -127,7 +132,7 @@
     NSString *description = [notification description];
     [[NSNotificationCenter defaultCenter] postNotification:notification];
     NSString *expectedDescription = [NSString stringWithFormat:@"expect not to receive \"MyNotification\" notification, but received: %@", description];
-    STAssertEqualObjects([matcher failureMessageForShouldNot], expectedDescription, @"failure message should match");
+    XCTAssertEqualObjects([matcher failureMessageForShouldNot], expectedDescription, @"failure message should match");
 }
 
 @end

--- a/Tests/KWNotificationMatcherTest.m
+++ b/Tests/KWNotificationMatcherTest.m
@@ -67,7 +67,7 @@
     id object = [NSObject new];
     id subject = @"MyNotification";
     KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:subject];
-    [matcher bePostedWithObject:object andUserInfo:@{@"a":@"b", @1:@2}];
+    [matcher bePostedWithObject:object userInfo:@{@"a":@"b", @1:@2}];
     [[NSNotificationCenter defaultCenter] postNotificationName:subject object:object userInfo:@{@"a":@"b", @1:@2}];
     XCTAssertTrue([matcher evaluate], @"expected positive match");
 }
@@ -120,7 +120,7 @@
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithObjectAndUserInfo {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
-    [matcher bePostedWithObject:@"sender" andUserInfo:@{@"message":@"text"}];
+    [matcher bePostedWithObject:@"sender" userInfo:@{@"message":@"text"}];
     XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
                          "notification with object: sender and user info: {\n    message = text;\n}", @"failure message should match");
 }

--- a/Tests/KWNotificationMatcherTest.m
+++ b/Tests/KWNotificationMatcherTest.m
@@ -37,6 +37,16 @@
     }
 }
 
+- (void)testCanMatchSubjectWithStringAndNotObject {
+    XCTAssertTrue([KWNotificationMatcher canMatchSubject:NSPortDidBecomeInvalidNotification], @"should be able to match notification name");
+    XCTAssertFalse([KWNotificationMatcher canMatchSubject:[NSObject new]], @"should not be able to match NSObject as a subject");
+}
+
+- (void)testShouldBeEvaluatedAtEndOfExample {
+    KWNotificationMatcher *matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
+    XCTAssertTrue([matcher shouldBeEvaluatedAtEndOfExample], @"should evaluate at the end of example to catch async notifications");
+}
+
 - (void)testItShouldMatchPostedNotificationWithAnyObject {
     id object = [NSObject new];
     id subject = @"MyNotification";

--- a/Tests/KWNotificationMatcherTest.m
+++ b/Tests/KWNotificationMatcherTest.m
@@ -32,7 +32,8 @@
 - (void)testEachMatcherStringIsANameOfAMatchingMethod {
     NSArray *matcherStrings = [KWNotificationMatcher matcherStrings];
     for (NSString *string in matcherStrings) {
-        XCTAssertTrue([KWNotificationMatcher instancesRespondToSelector:NSSelectorFromString(string)], @"expect to find an instance method: %@", string);
+        XCTAssertTrue([KWNotificationMatcher instancesRespondToSelector:NSSelectorFromString(string)],
+                      @"expect to find an instance method: %@", string);
     }
 }
 
@@ -101,28 +102,33 @@
 - (void)testItShouldHaveInformativeFailureMessageForShould {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePosted];
-    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" notification", @"failure message should match");
+    XCTAssertEqualObjects([matcher failureMessageForShould],
+                          @"expect to receive \"NSPortDidBecomeInvalidNotification\" notification",
+                          @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithObject {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePostedWithObject:@"sender"];
-    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
-                         "notification with object: sender", @"failure message should match");
+    XCTAssertEqualObjects([matcher failureMessageForShould],
+                          @"expect to receive \"NSPortDidBecomeInvalidNotification\" notification with object: sender",
+                          @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithUserInfo {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePostedWithUserInfo:@{@"message":@"text"}];
-    XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
-                         "notification with user info: {\n    message = text;\n}", @"failure message should match");
+    XCTAssertEqualObjects([matcher failureMessageForShould],
+                          @"expect to receive \"NSPortDidBecomeInvalidNotification\" notification with user info: {\n    message = text;\n}",
+                          @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldWithObjectAndUserInfo {
     id matcher = [KWNotificationMatcher matcherWithSubject:NSPortDidBecomeInvalidNotification];
     [matcher bePostedWithObject:@"sender" userInfo:@{@"message":@"text"}];
     XCTAssertEqualObjects([matcher failureMessageForShould], @"expect to receive \"NSPortDidBecomeInvalidNotification\" "
-                         "notification with object: sender and user info: {\n    message = text;\n}", @"failure message should match");
+                         "notification with object: sender and user info: {\n    message = text;\n}",
+                          @"failure message should match");
 }
 
 - (void)testItShouldHaveInformativeFailureMessageForShouldNot {


### PR DESCRIPTION
allow the use of notification matcher with async verifier in constructs like` [[@"my notification" shouldEventually] bePosted];` or even `shouldNotEventually` by keeping observer alive when evaluated multiple times until first notification received

Fixes https://github.com/kiwi-bdd/Kiwi/issues/592