### PR TITLE
Fix supportsSecureCoding for intercepted classes

### DIFF
--- a/Classes/Stubbing/KWIntercept.m
+++ b/Classes/Stubbing/KWIntercept.m
@@ -125,7 +125,10 @@ Class KWInterceptClassForCanonicalClass(Class canonicalClass) {
     SEL supportsSecureCodingSelector = @selector(supportsSecureCoding);
     Method supportsSecureCodingMethod = class_getClassMethod(canonicalClass, supportsSecureCodingSelector);
     if (supportsSecureCodingMethod != NULL) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         BOOL support = [(id)canonicalClass performSelector:supportsSecureCodingSelector];
+#pragma clang diagnostic pop
         IMP supportsSecureCodingIMP = support ? (IMP)KWInterceptedSupportsSecureCodingTrue
                                               : (IMP)KWInterceptedSupportsSecureCodingFalse;
         class_addMethod(interceptMetaClass, supportsSecureCodingSelector, supportsSecureCodingIMP, "B@:");

--- a/Classes/Stubbing/KWIntercept.m
+++ b/Classes/Stubbing/KWIntercept.m
@@ -37,6 +37,8 @@ void KWInterceptedForwardInvocation(id anObject, SEL aSelector, NSInvocation* an
 void KWInterceptedDealloc(id anObject, SEL aSelector);
 Class KWInterceptedClass(id anObject, SEL aSelector);
 Class KWInterceptedSuperclass(id anObject, SEL aSelector);
+BOOL KWInterceptedSupportsSecureCodingTrue(id anObject, SEL aSelector);
+BOOL KWInterceptedSupportsSecureCodingFalse(id anObject, SEL aSelector);
 
 #pragma mark - Getting Forwarding Implementations
 
@@ -119,6 +121,15 @@ Class KWInterceptClassForCanonicalClass(Class canonicalClass) {
 
     Class interceptMetaClass = object_getClass(interceptClass);
     class_addMethod(interceptMetaClass, @selector(forwardInvocation:), (IMP)KWInterceptedForwardInvocation, "v@:@");
+
+    SEL supportsSecureCodingSelector = @selector(supportsSecureCoding);
+    Method supportsSecureCodingMethod = class_getClassMethod(canonicalClass, supportsSecureCodingSelector);
+    if (supportsSecureCodingMethod != NULL) {
+        BOOL support = [(id)canonicalClass performSelector:supportsSecureCodingSelector];
+        IMP supportsSecureCodingIMP = support ? (IMP)KWInterceptedSupportsSecureCodingTrue
+                                              : (IMP)KWInterceptedSupportsSecureCodingFalse;
+        class_addMethod(interceptMetaClass, supportsSecureCodingSelector, supportsSecureCodingIMP, "B@:");
+    }
 
     return interceptClass;
 }
@@ -221,6 +232,14 @@ Class KWInterceptedSuperclass(id anObject, SEL aSelector) {
     Class originalClass = class_getSuperclass(interceptClass);
     Class originalSuperclass = class_getSuperclass(originalClass);
     return originalSuperclass;
+}
+
+BOOL KWInterceptedSupportsSecureCodingTrue(id anObject, SEL aSelector) {
+    return YES;
+}
+
+BOOL KWInterceptedSupportsSecureCodingFalse(id anObject, SEL aSelector) {
+    return NO;
 }
 
 #pragma mark - Managing Objects Stubs

--- a/Classes/Stubbing/KWIntercept.m
+++ b/Classes/Stubbing/KWIntercept.m
@@ -127,7 +127,7 @@ Class KWInterceptClassForCanonicalClass(Class canonicalClass) {
     if (supportsSecureCodingMethod != NULL) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        BOOL support = [(id)canonicalClass performSelector:supportsSecureCodingSelector];
+        BOOL support = (BOOL)[(id)canonicalClass performSelector:supportsSecureCodingSelector];
 #pragma clang diagnostic pop
         IMP supportsSecureCodingIMP = support ? (IMP)KWInterceptedSupportsSecureCodingTrue
                                               : (IMP)KWInterceptedSupportsSecureCodingFalse;

--- a/Tests/KWRealObjectStubTest.m
+++ b/Tests/KWRealObjectStubTest.m
@@ -195,6 +195,15 @@
     XCTAssertEqual([cruiser classification], @"Enterprise", @"expected method to be stubbed with block");
 }
 
+- (void)testStubSecureCodingOfDateClass {
+    NSDate *date = [NSDate date];
+    [NSDate stub:@selector(date) andReturn:date];
+    if (@available(iOS 11.0, *)) {
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:date requiringSecureCoding:YES error:NULL];
+        XCTAssertNotNil(data, @"expected stubbed class to be able to use secure coding");
+    }
+}
+
 @end
 
 #endif // #if KW_TESTS_ENABLED

--- a/Tests/KWRealObjectStubTest.m
+++ b/Tests/KWRealObjectStubTest.m
@@ -198,7 +198,7 @@
 - (void)testStubSecureCodingOfDateClass {
     NSDate *date = [NSDate date];
     [NSDate stub:@selector(date) andReturn:date];
-    if (@available(iOS 11.0, *)) {
+    if (@available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)) {
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:date requiringSecureCoding:YES error:NULL];
         XCTAssertNotNil(data, @"expected stubbed class to be able to use secure coding");
     }


### PR DESCRIPTION
Hi!

For at least a year I've been meeting the same problem: if there is an NSDate stub and test fails, test run fails(crashes) with something like this:

> Class 'NSDate' has a superclass that supports secure coding, but 'NSDate' overrides -initWithCoder: and does not override +supportsSecureCoding. The class must implement +supportsSecureCoding and return YES to verify that its implementation of -initWithCoder: is secure coding compliant.

Today I've finally decided to figure out what is the problem. It all ended up with this patch.
Maybe someone has any idea about how to solve the problem more properly?
