### PR TITLE
Removes duplicate of captureArgument

### DIFF
--- a/Classes/Stubbing/NSObject+KiwiStubAdditions.h
+++ b/Classes/Stubbing/NSObject+KiwiStubAdditions.h
@@ -46,11 +46,9 @@
 
 - (void)addMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern;
 - (void)removeMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern;
-- (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
 
 + (void)addMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern;
 + (void)removeMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern;
-+ (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
 
 @end
 

--- a/Classes/Stubbing/NSObject+KiwiStubAdditions.m
+++ b/Classes/Stubbing/NSObject+KiwiStubAdditions.m
@@ -222,12 +222,6 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
     KWClearObjectSpy(self, aSpy, aMessagePattern);
 }
 
-- (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index {
-    KWCaptureSpy *spy = [[KWCaptureSpy alloc] initWithArgumentIndex:index];
-    [self addMessageSpy:spy forMessagePattern:[KWMessagePattern messagePatternWithSelector:selector]];
-    return spy;
-}
-
 + (void)addMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern {
     if ([self methodSignatureForSelector:aMessagePattern.selector] == nil) {
         [NSException raise:@"KWSpyException" format:@"cannot add spy for -%@ because no such method exists",
@@ -241,12 +235,6 @@ static NSString * const ChangeStubValueAfterTimesKey = @"ChangeStubValueAfterTim
 
 + (void)removeMessageSpy:(id<KWMessageSpying>)aSpy forMessagePattern:(KWMessagePattern *)aMessagePattern {
     KWClearObjectSpy(self, aSpy, aMessagePattern);
-}
-
-+ (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index {
-    KWCaptureSpy *spy = [[KWCaptureSpy alloc] initWithArgumentIndex:index];
-    [self addMessageSpy:spy forMessagePattern:[KWMessagePattern messagePatternWithSelector:selector]];
-    return spy;
 }
 
 @end


### PR DESCRIPTION
### Problem

On compiling the framework with **Xcode 11**, I've got the following warnings:

![Screenshot 2020-01-31 at 10 59 05](https://user-images.githubusercontent.com/54804348/73534307-bda78e00-4418-11ea-8883-8472724e4afb.png)

The problem is that the function `captureArgument:atIndex:` is defined in both `KiwiSpyAdditions` and `KiwiStubAdditions` additions: 

- `KiwiSpyAdditions`

```
@protocol KiwiSpyAdditions <NSObject>
- (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
+ (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
@end

@interface NSObject (KiwiSpyAdditions) <KiwiSpyAdditions>
```

- `KiwiStubAdditions`

```
@protocol KiwiStubAdditions <NSObject>
- (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
+ (KWCaptureSpy *)captureArgument:(SEL)selector atIndex:(NSUInteger)index;
@end

@interface NSObject(KiwiStubAdditions) <KiwiStubAdditions>
```

### Solution

This PR removes the duplicated `captureArgument:atIndex:` (both class and instance) methods from `KiwiStubAdditions`, which were added in the following commit: https://github.com/kiwi-bdd/Kiwi/commit/592b25a8f7d7cb0c67b4b685366fd482be8b8492#diff-a7e330fecdc419920d8bf144bf9fc881

If needed, It's enough to import `Kiwi.h` to be able to access to `captureArgument:atIndex:` because all the `NSObject` categories are already being imported (including `NSObject+KiwiSpyAdditions.h`):

![Screenshot 2020-01-31 at 11 09 27](https://user-images.githubusercontent.com/54804348/73534879-2b07ee80-441a-11ea-8d69-f9256d0debdb.png)

---
Please note that the implementation of `captureArgument:atIndex:` from `NSObject+KiwiSpyAdditions.h` and `NSObject+KiwiStubAdditions.h` are exactly the same, so it won't generate any breaking changes to the external projects. They are both categories of the same `NSObject`.
